### PR TITLE
feat(fields)!: add disabled, error & label props to CoordinatesInput

### DIFF
--- a/src/elements/Fieldset.tsx
+++ b/src/elements/Fieldset.tsx
@@ -4,7 +4,7 @@ import styled, { css } from 'styled-components'
 import { Field } from './Field'
 import { Legend } from './Legend'
 
-export type FieldsetProps = FieldsetHTMLAttributes<HTMLFieldSetElement> & {
+export type FieldsetProps = Omit<FieldsetHTMLAttributes<HTMLFieldSetElement>, 'defaultValue' | 'onChange' | 'value'> & {
   hasBorder?: boolean | undefined
   isLegendHidden?: boolean | undefined
   isLight?: boolean | undefined

--- a/src/fields/CoordinatesInput/DDCoordinatesInput.tsx
+++ b/src/fields/CoordinatesInput/DDCoordinatesInput.tsx
@@ -4,11 +4,20 @@ import { useDebouncedCallback } from 'use-debounce'
 
 import { isNumeric } from '../../utils/isNumeric'
 
+import type { Coordinates } from '../../types'
+
 type DDCoordinatesInputProps = {
-  coordinates: [number, number]
-  onChange: (nextCoordinates: [number, number], coordinates: [number, number]) => void
+  coordinates: Coordinates | undefined
+  disabled: boolean | undefined
+  onChange: (nextCoordinates: Coordinates, coordinates: Coordinates | undefined) => void
 }
-export function DDCoordinatesInput({ coordinates, onChange }: DDCoordinatesInputProps) {
+// TODO This field should return undefined when cleared (i.e.: Select all & Backspace/Delete)
+export function DDCoordinatesInput({
+  coordinates,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  disabled = false,
+  onChange
+}: DDCoordinatesInputProps) {
   const latitudeInputRef = useRef<HTMLInputElement>()
   const longitudeInputRef = useRef<HTMLInputElement>()
 
@@ -16,6 +25,10 @@ export function DDCoordinatesInput({ coordinates, onChange }: DDCoordinatesInput
   const [longitudeError, setLongitudeError] = useState('')
 
   const defaultValue = useMemo(() => {
+    if (!coordinates) {
+      return undefined
+    }
+
     const [latitude, longitude] = coordinates
 
     if (isNumeric(latitude) && isNumeric(longitude)) {
@@ -31,7 +44,7 @@ export function DDCoordinatesInput({ coordinates, onChange }: DDCoordinatesInput
     }
   }, [coordinates])
 
-  const handleChange = useDebouncedCallback((nextCoordinates: [number, number]) => {
+  const handleChange = useDebouncedCallback((nextCoordinates: [number, number] | undefined) => {
     if (!latitudeInputRef.current || !longitudeInputRef.current) {
       return
     }
@@ -65,7 +78,8 @@ export function DDCoordinatesInput({ coordinates, onChange }: DDCoordinatesInput
       <DDInput
         ref={latitudeInputRef as any}
         data-cy="coordinates-dd-input-lat"
-        defaultValue={defaultValue.latitude}
+        defaultValue={defaultValue ? defaultValue.latitude : undefined}
+        disabled={disabled}
         onChange={() => handleChange(coordinates)}
         placeholder="Latitude"
         style={{ border: latitudeError ? '1px solid red' : undefined }}
@@ -73,7 +87,8 @@ export function DDCoordinatesInput({ coordinates, onChange }: DDCoordinatesInput
       <DDInput
         ref={longitudeInputRef as any}
         data-cy="coordinates-dd-input-lon"
-        defaultValue={defaultValue.longitude}
+        defaultValue={defaultValue ? defaultValue.longitude : undefined}
+        disabled={disabled}
         onChange={() => handleChange(coordinates)}
         placeholder="Longitude"
         style={{ border: longitudeError ? '1px solid red' : undefined }}

--- a/src/fields/CoordinatesInput/DMDCoordinatesInput.tsx
+++ b/src/fields/CoordinatesInput/DMDCoordinatesInput.tsx
@@ -8,16 +8,26 @@ import { getCoordinates } from '../../utils/coordinates'
 import { isNumeric } from '../../utils/isNumeric'
 import { CoordinatesFormat } from './constants'
 
+import type { Coordinates } from '../../types'
+
 // TODO Remove that once the fix is added and released.
 // Open issue: https://github.com/uNmAnNeR/imaskjs/issues/761
 const UntypedIMaskInput: any = IMaskInput
 
 type DMDCoordinatesInputProps = {
-  coordinates: number[]
+  coordinates: Coordinates | undefined
   coordinatesFormat: CoordinatesFormat
-  onChange: (nextCoordinates: number[], coordinates: number[]) => void
+  disabled: boolean | undefined
+  onChange: (nextCoordinates: Coordinates, coordinates: Coordinates | undefined) => void
 }
-export function DMDCoordinatesInput({ coordinates, coordinatesFormat, onChange }: DMDCoordinatesInputProps) {
+// TODO This field should return undefined when cleared (i.e.: Select all & Backspace/Delete)
+export function DMDCoordinatesInput({
+  coordinates,
+  coordinatesFormat,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  disabled = false,
+  onChange
+}: DMDCoordinatesInputProps) {
   const [error, setError] = useState('')
   const [value, setValue] = useState('')
 
@@ -88,6 +98,7 @@ export function DMDCoordinatesInput({ coordinates, coordinatesFormat, onChange }
     <Box>
       <UntypedIMaskInput
         data-cy="dmd-coordinates-input"
+        disabled={disabled}
         lazy={false}
         mask="00° 00.000′ a 000° 00.000′ a"
         // @ts-ignore
@@ -96,6 +107,7 @@ export function DMDCoordinatesInput({ coordinates, coordinatesFormat, onChange }
         placeholder="__° __.___′ _ ___° __.___′"
         radix="."
         style={{ border: error ? '1px solid red' : undefined }}
+        // TODO Use `defaultValue` here.
         value={value}
       />
       <CoordinatesType>(DMD)</CoordinatesType>

--- a/src/fields/CoordinatesInput/DMSCoordinatesInput.tsx
+++ b/src/fields/CoordinatesInput/DMSCoordinatesInput.tsx
@@ -1,17 +1,26 @@
+import { isEmpty } from 'ramda'
 import { useCallback, useMemo } from 'react'
 import CoordinateInput from 'react-coordinate-input'
 import styled from 'styled-components'
 
+import type { Coordinates } from '../../types'
 import type { CoordinatesFormat } from './constants'
 
 type DMSCoordinatesInputProps = {
-  coordinates: number[]
+  coordinates: Coordinates | undefined
   coordinatesFormat: CoordinatesFormat
-  onChange: (nextCoordinates: number[], coordinates: number[]) => void
+  disabled: boolean | undefined
+  onChange: (nextCoordinates: Coordinates | undefined, coordinates: Coordinates | undefined) => void
 }
-export function DMSCoordinatesInput({ coordinates, coordinatesFormat, onChange }: DMSCoordinatesInputProps) {
+export function DMSCoordinatesInput({
+  coordinates,
+  coordinatesFormat,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  disabled = false,
+  onChange
+}: DMSCoordinatesInputProps) {
   /** Convert the coordinates to the [latitude, longitude] string format */
-  const showedValue = useMemo(() => {
+  const defaultValue = useMemo(() => {
     if (!coordinates?.length || !coordinatesFormat) {
       return ''
     }
@@ -21,7 +30,9 @@ export function DMSCoordinatesInput({ coordinates, coordinatesFormat, onChange }
 
   const update = useCallback(
     nextCoordinates => {
-      onChange(nextCoordinates, coordinates)
+      const normalizedNextCoordinates = !isEmpty(nextCoordinates) ? nextCoordinates : undefined
+
+      onChange(normalizedNextCoordinates, coordinates)
     },
     [coordinates, onChange]
   )
@@ -31,8 +42,10 @@ export function DMSCoordinatesInput({ coordinates, coordinatesFormat, onChange }
       <CoordinateInput
         data-cy="dms-coordinates-input"
         ddPrecision={6}
+        disabled={disabled}
         onChange={(_, { dd }) => update(dd)}
-        value={showedValue}
+        // TODO Use `defaultValue` here.
+        value={defaultValue}
       />
       <CoordinatesType>(DMS)</CoordinatesType>
     </Box>

--- a/src/fields/CoordinatesInput/index.tsx
+++ b/src/fields/CoordinatesInput/index.tsx
@@ -1,25 +1,46 @@
-import { useCallback } from 'react'
+import { useCallback, useMemo } from 'react'
 import styled from 'styled-components'
 
+import { FieldError } from '../../elements/FieldError'
+import { Fieldset } from '../../elements/Fieldset'
+import { useFieldUndefineEffect } from '../../hooks/useFieldUndefineEffect'
+import { noop } from '../../utils/noop'
+import { normalizeString } from '../../utils/normalizeString'
 import { CoordinatesFormat } from './constants'
 import { DDCoordinatesInput } from './DDCoordinatesInput'
 import { DMDCoordinatesInput } from './DMDCoordinatesInput'
 import { DMSCoordinatesInput } from './DMSCoordinatesInput'
 
+import type { FieldsetProps } from '../../elements/Fieldset'
+import type { Coordinates } from '../../types'
 import type { Promisable } from 'type-fest'
 
-export type CoordinatesInputProps = {
+export type CoordinatesInputProps = FieldsetProps & {
   coordinatesFormat: CoordinatesFormat
-  defaultValue: number[]
+  defaultValue?: Coordinates | undefined
+  disabled?: boolean | undefined
+  error?: string | undefined
+  isLabelHidden?: boolean | undefined
   isLight?: boolean | undefined
-  onChange: (nextCoordinates: number[], coordinates: number[]) => Promisable<void>
+  label: string
+  onChange?:
+    | ((nextCoordinates: Coordinates | undefined, coordinates: Coordinates | undefined) => Promisable<void>)
+    | undefined
 }
 export function CoordinatesInput({
   coordinatesFormat,
   defaultValue,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  error,
+  isLabelHidden = false,
   isLight = false,
-  onChange
+  label,
+  onChange = noop,
+  ...nativeProps
 }: CoordinatesInputProps) {
+  const controlledError = useMemo(() => normalizeString(error), [error])
+  const hasError = useMemo(() => Boolean(controlledError), [controlledError])
+
   const getCoordinatesInput = useCallback(() => {
     switch (coordinatesFormat) {
       case CoordinatesFormat.DEGREES_MINUTES_SECONDS:
@@ -27,37 +48,51 @@ export function CoordinatesInput({
           <DMSCoordinatesInput
             coordinates={defaultValue}
             coordinatesFormat={CoordinatesFormat.DEGREES_MINUTES_SECONDS}
+            disabled={nativeProps.disabled}
             onChange={onChange}
           />
         )
+
       case CoordinatesFormat.DEGREES_MINUTES_DECIMALS:
         return (
           <DMDCoordinatesInput
             coordinates={defaultValue}
             coordinatesFormat={CoordinatesFormat.DEGREES_MINUTES_DECIMALS}
+            disabled={nativeProps.disabled}
             onChange={onChange}
           />
         )
+
       case CoordinatesFormat.DECIMAL_DEGREES:
-        return <DDCoordinatesInput coordinates={defaultValue as [number, number]} onChange={onChange} />
+        return (
+          <DDCoordinatesInput
+            coordinates={defaultValue as [number, number]}
+            disabled={nativeProps.disabled}
+            onChange={onChange}
+          />
+        )
+
       default:
         return undefined
     }
-  }, [defaultValue, onChange, coordinatesFormat])
+  }, [defaultValue, nativeProps.disabled, onChange, coordinatesFormat])
 
-  return <Box $isLight={isLight}>{getCoordinatesInput()}</Box>
+  // TODO We must add a `handleDisable()` callback here to effectively empty the inputs when disabling this field.
+  useFieldUndefineEffect(nativeProps.disabled, onChange /* , handleDisable */)
+
+  return (
+    <StyledFieldset isLegendHidden={isLabelHidden} isLight={isLight} legend={label} {...nativeProps}>
+      {getCoordinatesInput()}
+
+      {hasError && <FieldError>{controlledError}</FieldError>}
+    </StyledFieldset>
+  )
 }
 
-const Box = styled.div<{
-  $isLight: boolean
-}>`
-  color: ${p => p.theme.color.lightGray};
-  font-size: 13px;
-  text-align: left;
-
+const StyledFieldset = styled(Fieldset)`
   input {
-    background-color: ${p => (p.$isLight ? p.theme.color.white : p.theme.color.gainsboro)};
-    border: ${p => (p.$isLight ? `1px solid ${p.theme.color.lightGray}` : 'none')};
+    background-color: ${p => (p.isLight ? p.theme.color.white : p.theme.color.gainsboro)};
+    border: ${p => (p.isLight ? `1px solid ${p.theme.color.lightGray}` : 'none')};
     color: ${p => p.theme.color.gunMetal};
     height: 33px;
     padding: 7px 11px;

--- a/src/formiks/FormikCoordinatesInput.tsx
+++ b/src/formiks/FormikCoordinatesInput.tsx
@@ -1,0 +1,20 @@
+import { useField } from 'formik'
+import { useMemo } from 'react'
+
+import { CoordinatesInput } from '../fields/CoordinatesInput'
+
+import type { CoordinatesInputProps } from '../fields/CoordinatesInput'
+
+export type FormikCoordinatesInputProps = Omit<CoordinatesInputProps, 'defaultValue' | 'error' | 'onChange'> & {
+  name: string
+}
+export function FormikCoordinatesInput({ name, ...originalProps }: FormikCoordinatesInputProps) {
+  const [field, meta, helpers] = useField(name)
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const defaultValue = useMemo(() => field.value, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleChange = useMemo(() => (nextCoordinates: number[] | undefined) => helpers.setValue(nextCoordinates), [])
+
+  return <CoordinatesInput defaultValue={defaultValue} error={meta.error} onChange={handleChange} {...originalProps} />
+}

--- a/src/hooks/useFieldUndefineEffect.ts
+++ b/src/hooks/useFieldUndefineEffect.ts
@@ -5,7 +5,7 @@ import type { Promisable } from 'type-fest'
 export function useFieldUndefineEffect(
   // eslint-disable-next-line @typescript-eslint/naming-convention
   disabled: boolean | undefined,
-  onChange: ((nextValue: any) => Promisable<void>) | undefined,
+  onChange: ((nextValue: any, ...args: any[]) => Promisable<void>) | undefined,
   onDisable?: () => Promisable<void>
 ) {
   useEffect(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ export { TextInput } from './fields/TextInput'
 
 export { FormikAutoComplete } from './formiks/FormikAutoComplete'
 export { FormikCheckbox } from './formiks/FormikCheckbox'
+export { FormikCoordinatesInput } from './formiks/FormikCoordinatesInput'
 export { FormikDatePicker } from './formiks/FormikDatePicker'
 export { FormikDateRangePicker } from './formiks/FormikDateRangePicker'
 export { FormikEffect } from './formiks/FormikEffect'
@@ -106,6 +107,7 @@ export type { TextInputProps } from './fields/TextInput'
 
 export type { FormikAutoCompleteProps } from './formiks/FormikAutoComplete'
 export type { FormikCheckboxProps } from './formiks/FormikCheckbox'
+export type { FormikCoordinatesInputProps } from './formiks/FormikCoordinatesInput'
 export type { FormikDatePickerWithDateDateProps, FormikDatePickerWithStringDateProps } from './formiks/FormikDatePicker'
 export type {
   FormikDateRangePickerWithDateDateProps,

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,7 +76,7 @@ export { stopMouseEventPropagation } from './utils/stopMouseEventPropagation'
 */
 
 export type { PartialTheme, Theme } from './theme'
-export type { DateAsStringRange, DateRange, IconProps, Option, Undefine } from './types'
+export type { Coordinates, DateAsStringRange, DateRange, IconProps, Option, Undefine } from './types'
 
 export type { DropdownProps, DropdownItemProps } from './components/Dropdown'
 export type { SingleTagProps } from './components/SingleTag'

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 import type { SVGProps } from 'react'
 
+export type Coordinates = [number, number]
+
 export type DateRange = [Date, Date]
 export type DateAsStringRange = [string, string]
 

--- a/stories/fields/CoordinatesInput.stories.tsx
+++ b/stories/fields/CoordinatesInput.stories.tsx
@@ -9,7 +9,11 @@ import type { CoordinatesInputProps } from '../../src/fields/CoordinatesInput'
 const args: CoordinatesInputProps = {
   defaultValue: [],
   coordinatesFormat: CoordinatesFormat.DEGREES_MINUTES_SECONDS,
-  onChange: () => {}
+  disabled: false,
+  error: '',
+  isLabelHidden: false,
+  isLight: false,
+  label: 'Some coordinates'
 }
 
 export default {

--- a/stories/fields/CoordinatesInput.stories.tsx
+++ b/stories/fields/CoordinatesInput.stories.tsx
@@ -7,7 +7,7 @@ import { CoordinatesFormat, CoordinatesInput } from '../../src'
 import type { CoordinatesInputProps } from '../../src/fields/CoordinatesInput'
 
 const args: CoordinatesInputProps = {
-  defaultValue: [],
+  defaultValue: undefined,
   coordinatesFormat: CoordinatesFormat.DEGREES_MINUTES_SECONDS,
   disabled: false,
   error: '',
@@ -36,7 +36,7 @@ export default {
 }
 
 export function _CoordinatesInput(props: CoordinatesInputProps) {
-  const [outputValue, setOutputValue] = useState<number[] | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState<number[] | undefined | '∅'>('∅')
 
   return (
     <>

--- a/stories/formiks/FormikCoordinatesInput.stories.tsx
+++ b/stories/formiks/FormikCoordinatesInput.stories.tsx
@@ -1,0 +1,60 @@
+import { Formik } from 'formik'
+import { useMemo, useState } from 'react'
+
+import { Output } from '../../.storybook/components/Output'
+import { generateStoryDecorator } from '../../.storybook/components/StoryDecorator'
+import { FormikEffect, FormikCoordinatesInput, CoordinatesFormat } from '../../src'
+import { noop } from '../../src/utils/noop'
+
+import type { FormikCoordinatesInputProps } from '../../src'
+
+const args: FormikCoordinatesInputProps = {
+  coordinatesFormat: CoordinatesFormat.DECIMAL_DEGREES,
+  isLight: false,
+  label: 'Some coordinates',
+  name: 'myCoordinates'
+}
+
+export default {
+  title: 'Formiks/FormikCoordinatesInput',
+  component: FormikCoordinatesInput,
+  args,
+
+  argTypes: {
+    accent: {
+      control: 'inline-radio',
+      options: CoordinatesFormat
+    }
+  },
+
+  decorators: [
+    generateStoryDecorator({
+      hasDarkMode: true
+    })
+  ]
+}
+
+export function _FormikCoordinatesInput(props: FormikCoordinatesInputProps) {
+  const [outputValue, setOutputValue] = useState<
+    | {
+        myCoordinates?: number[]
+      }
+    | '∅'
+  >('∅')
+
+  const key = useMemo(() => props.name, [props.name])
+
+  return (
+    <>
+      <Formik key={key} initialValues={{}} onSubmit={noop}>
+        <>
+          <FormikEffect onChange={setOutputValue} />
+
+          <FormikCoordinatesInput {...props} />
+        </>
+      </Formik>
+
+      {outputValue !== '∅' && <Output value={outputValue} />}
+    </>
+  )
+}


### PR DESCRIPTION
BREAKING CHANGE: CoordinatesInput onChange can now send undefined params
BREAKING CHANGE: label is now mandatory in CoordinatesInput

## Related Pull Requests & Issues

None

## Preview URL

https://637e01cf5934a2ae881ccc9d-snerbxtmcv.chromatic.com/
