### PR TITLE
fix(deps): downgrade cypress version

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,7 @@
     "yup": "1.0.0"
   },
   "peerDependencies": {
-    "cypress": "^12.0.0",
+    "cypress": "^10.0.0",
     "formik": "^2.0.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3049,7 +3049,7 @@ __metadata:
     webpack: 5.75.0
     yup: 1.0.0
   peerDependencies:
-    cypress: ^12.0.0
+    cypress: ^10.0.0
     formik: ^2.0.0
     react: ^18.0.0
     react-dom: ^18.0.0


### PR DESCRIPTION
## Related Pull Requests & Issues

Because Cypress v12 is not in peer deps of https://github.com/ivangabriele/cypress-plugin-snapshots in last tag

## Preview URL

https://637e01cf5934a2ae881ccc9d-iwzonhnhem.chromatic.com/
