### PR TITLE
fix(fields): controlled InputNumber + remove internal states

### DIFF
--- a/e2e/base/formiks/All.spec.tsx
+++ b/e2e/base/formiks/All.spec.tsx
@@ -19,14 +19,13 @@ context('All', () => {
     cy.fill('Text input', 'A text input value')
 
     outputShouldBe({
-      checkbox: false,
       textInput: 'A text input value'
     })
 
     cy.fill('Text input', undefined)
 
     outputShouldBe({
-      checkbox: false
+      textInput: ''
     })
   })
 
@@ -34,7 +33,6 @@ context('All', () => {
     cy.fill('Text input with hidden label', 'A text input with hidden label value')
 
     outputShouldBe({
-      checkbox: false,
       textInputWithHiddenLabel: 'A text input with hidden label value'
     })
   })
@@ -43,14 +41,13 @@ context('All', () => {
     cy.fill('Textarea', 'A textarea value')
 
     outputShouldBe({
-      checkbox: false,
       textarea: 'A textarea value'
     })
 
     cy.fill('Textarea', undefined)
 
     outputShouldBe({
-      checkbox: false
+      textarea: ''
     })
   })
 
@@ -58,7 +55,6 @@ context('All', () => {
     cy.fill('Textarea with hidden label', 'A textarea with hidden label value')
 
     outputShouldBe({
-      checkbox: false,
       textareaWithHiddenLabel: 'A textarea with hidden label value'
     })
   })
@@ -81,22 +77,18 @@ context('All', () => {
     cy.fill('Select', 'Second select option')
 
     outputShouldBe({
-      checkbox: false,
       select: 'SECOND_SELECT_OPTION'
     })
 
     cy.fill('Select', undefined)
 
-    outputShouldBe({
-      checkbox: false
-    })
+    outputShouldBe({})
   })
 
   it('Should select the 42th option in the select with a search input', () => {
     cy.fill('Select with search input', 'Select with search input option 42')
 
     outputShouldBe({
-      checkbox: false,
       selectWithSearchInput: 'SELECT_WITH_SEARCH_INPUT_OPTION_42'
     })
   })
@@ -105,7 +97,6 @@ context('All', () => {
     cy.fill('Select with hidden label', 'Second select with hidden label option')
 
     outputShouldBe({
-      checkbox: false,
       selectWithHiddenLabel: 'SECOND_SELECT_WITH_HIDDEN_LABEL_OPTION'
     })
   })
@@ -114,15 +105,12 @@ context('All', () => {
     cy.fill('Multi select', ['Second multi select option', 'Third multi select option'])
 
     outputShouldBe({
-      checkbox: false,
       multiSelect: ['SECOND_MULTI_SELECT_OPTION', 'THIRD_MULTI_SELECT_OPTION']
     })
 
     cy.fill('Multi select', undefined)
 
-    outputShouldBe({
-      checkbox: false
-    })
+    outputShouldBe({})
   })
 
   it('Should select the 21st and 42th option in the multi select with a search input', () => {
@@ -132,7 +120,6 @@ context('All', () => {
     ])
 
     outputShouldBe({
-      checkbox: false,
       multiSelectWithSearchInput: [
         'MULTI_SELECT_WITH_SEARCH_INPUT_OPTION_21',
         'MULTI_SELECT_WITH_SEARCH_INPUT_OPTION_42'
@@ -147,7 +134,6 @@ context('All', () => {
     ])
 
     outputShouldBe({
-      checkbox: false,
       multiSelectWithHiddenLabel: [
         'SECOND_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION',
         'THIRD_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION'
@@ -159,15 +145,12 @@ context('All', () => {
     cy.fill('Multi checkbox', ['Second multi checkbox option', 'Third multi checkbox option'])
 
     outputShouldBe({
-      checkbox: false,
       multiCheckbox: ['SECOND_MULTI_CHECKBOX_OPTION', 'THIRD_MULTI_CHECKBOX_OPTION']
     })
 
     cy.fill('Multi checkbox', undefined)
 
-    outputShouldBe({
-      checkbox: false
-    })
+    outputShouldBe({ multiCheckbox: [] })
   })
 
   it('Should check the 2nd and 3rd option in the multi checkbox with a hidden label', () => {
@@ -177,7 +160,6 @@ context('All', () => {
     ])
 
     outputShouldBe({
-      checkbox: false,
       multiCheckboxWithHiddenLabel: [
         'SECOND_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION',
         'THIRD_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
@@ -189,7 +171,6 @@ context('All', () => {
     cy.fill('Multi radio', 'Second multi radio option')
 
     outputShouldBe({
-      checkbox: false,
       multiRadio: 'SECOND_MULTI_RADIO_OPTION'
     })
   })
@@ -198,7 +179,6 @@ context('All', () => {
     cy.fill('Multi radio with hidden label', 'Second multi radio with hidden label option')
 
     outputShouldBe({
-      checkbox: false,
       multiRadioWithHiddenLabel: 'SECOND_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
     })
   })

--- a/e2e/base/formiks/All.spec.tsx
+++ b/e2e/base/formiks/All.spec.tsx
@@ -15,7 +15,7 @@ context('All', () => {
     )
   })
 
-  it('Should fill, change and clear the select', () => {
+  it('Should fill, change and clear the text input', () => {
     cy.fill('Text input', 'A text input value')
 
     outputShouldBe({
@@ -27,6 +27,26 @@ context('All', () => {
     outputShouldBe({
       textInput: ''
     })
+  })
+
+  it('Should set input to undefined when input is disabled', () => {
+    cy.fill('Text input', 'A text input value')
+
+    outputShouldBe({
+      textInput: 'A text input value'
+    })
+
+    cy.fill('Read only ?', true)
+
+    outputShouldBe({
+      textInput: 'A text input value'
+    })
+
+    cy.fill('Read only ?', false)
+    cy.fill('set to undefined when field is disabled', true)
+
+    cy.fill('Read only ?', true)
+    outputShouldBe({})
   })
 
   it('Should fill the text input with a hidden label', () => {
@@ -51,6 +71,26 @@ context('All', () => {
     })
   })
 
+  it('Should set textarea to undefined when textarea is disabled', () => {
+    cy.fill('Textarea', 'A text area value')
+
+    outputShouldBe({
+      textarea: 'A text area value'
+    })
+
+    cy.fill('Read only ?', true)
+
+    outputShouldBe({
+      textarea: 'A text area value'
+    })
+
+    cy.fill('Read only ?', false)
+    cy.fill('set to undefined when field is disabled', true)
+
+    cy.fill('Read only ?', true)
+    outputShouldBe({})
+  })
+
   it('Should fill the textarea with a hidden label', () => {
     cy.fill('Textarea with hidden label', 'A textarea with hidden label value')
 
@@ -73,6 +113,26 @@ context('All', () => {
     })
   })
 
+  it('Should set checkbox to undefined when checkbox is disabled', () => {
+    cy.fill('Checkbox', true)
+
+    outputShouldBe({
+      checkbox: true
+    })
+
+    cy.fill('Read only ?', true)
+
+    outputShouldBe({
+      checkbox: true
+    })
+
+    cy.fill('Read only ?', false)
+    cy.fill('set to undefined when field is disabled', true)
+
+    cy.fill('Read only ?', true)
+    outputShouldBe({})
+  })
+
   it('Should select the 2nd option in the select, and clear it', () => {
     cy.fill('Select', 'Second select option')
 
@@ -82,6 +142,26 @@ context('All', () => {
 
     cy.fill('Select', undefined)
 
+    outputShouldBe({})
+  })
+
+  it('Should set select to undefined when select is disabled', () => {
+    cy.fill('Select', 'Second select option')
+
+    outputShouldBe({
+      select: 'SECOND_SELECT_OPTION'
+    })
+
+    cy.fill('Read only ?', true)
+
+    outputShouldBe({
+      select: 'SECOND_SELECT_OPTION'
+    })
+
+    cy.fill('Read only ?', false)
+    cy.fill('set to undefined when field is disabled', true)
+
+    cy.fill('Read only ?', true)
     outputShouldBe({})
   })
 
@@ -167,6 +247,35 @@ context('All', () => {
     })
   })
 
+  it('Should set multicheckbox to undefined when multicheckbox is disabled', () => {
+    cy.fill('Multi checkbox with hidden label', [
+      'Second multi checkbox with hidden label option',
+      'Third multi checkbox with hidden label option'
+    ])
+
+    outputShouldBe({
+      multiCheckboxWithHiddenLabel: [
+        'SECOND_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION',
+        'THIRD_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
+      ]
+    })
+
+    cy.fill('Read only ?', true)
+
+    outputShouldBe({
+      multiCheckboxWithHiddenLabel: [
+        'SECOND_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION',
+        'THIRD_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
+      ]
+    })
+
+    cy.fill('Read only ?', false)
+    cy.fill('set to undefined when field is disabled', true)
+
+    cy.fill('Read only ?', true)
+    outputShouldBe({})
+  })
+
   it('Should check the 2nd option in the multi radio, and clear them', () => {
     cy.fill('Multi radio', 'Second multi radio option')
 
@@ -181,5 +290,25 @@ context('All', () => {
     outputShouldBe({
       multiRadioWithHiddenLabel: 'SECOND_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
     })
+  })
+
+  it('Should set multiradio to undefined when multiradio is disabled', () => {
+    cy.fill('Multi radio', 'Second multi radio option')
+
+    outputShouldBe({
+      multiRadio: 'SECOND_MULTI_RADIO_OPTION'
+    })
+
+    cy.fill('Read only ?', true)
+
+    outputShouldBe({
+      multiRadio: 'SECOND_MULTI_RADIO_OPTION'
+    })
+
+    cy.fill('Read only ?', false)
+    cy.fill('set to undefined when field is disabled', true)
+
+    cy.fill('Read only ?', true)
+    outputShouldBe({})
   })
 })

--- a/src/fields/Checkbox.tsx
+++ b/src/fields/Checkbox.tsx
@@ -6,7 +6,6 @@ import styled from 'styled-components'
 
 import { Field } from '../elements/Field'
 import { FieldError } from '../elements/FieldError'
-import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 import { normalizeString } from '../utils/normalizeString'
 
 import type { CheckboxProps as RsuiteCheckboxProps } from 'rsuite'
@@ -17,7 +16,6 @@ export type CheckboxProps = Omit<RsuiteCheckboxProps, 'as' | 'checked' | 'defaul
   checked?: boolean | undefined
   error?: string | undefined
   isErrorMessageHidden?: boolean | undefined
-  isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
   onChange?: ((isCheched: boolean) => Promisable<void>) | undefined
@@ -26,7 +24,6 @@ export function Checkbox({
   checked = false,
   error,
   isErrorMessageHidden = false,
-  isUndefinedWhenDisabled = false,
   label,
   onChange,
   ...originalProps
@@ -42,8 +39,6 @@ export function Checkbox({
     },
     [onChange]
   )
-
-  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, onChange)
 
   return (
     <Field className="Field-Checkbox">

--- a/src/fields/Checkbox.tsx
+++ b/src/fields/Checkbox.tsx
@@ -64,6 +64,12 @@ const StyledCheckbox = styled(RsuiteCheckbox)`
     .rs-checkbox-wrapper {
       left: 2px;
       top: 2px !important;
+      &:after {
+        bottom: 0;
+        left: 0;
+        right: 0;
+        top: 0;
+      }
     }
   }
 `

--- a/src/fields/Checkbox.tsx
+++ b/src/fields/Checkbox.tsx
@@ -1,15 +1,12 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import { Checkbox as RsuiteCheckbox } from 'rsuite'
 import styled from 'styled-components'
 
 import { Field } from '../elements/Field'
 import { FieldError } from '../elements/FieldError'
 import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
-import { useForceUpdate } from '../hooks/useForceUpdate'
-import { usePrevious } from '../hooks/usePrevious'
-import { getPseudoRandomString } from '../utils/getPseudoRandomString'
 import { normalizeString } from '../utils/normalizeString'
 
 import type { CheckboxProps as RsuiteCheckboxProps } from 'rsuite'
@@ -34,55 +31,23 @@ export function Checkbox({
   onChange,
   ...originalProps
 }: CheckboxProps) {
-  const { forceUpdate } = useForceUpdate()
-
-  // This tracks the component internal value which allows us to react to value changes after the checkbox toggling
-  const [internalChecked, setInternalChecked] = useState(checked)
-
-  // and compare it with an eventual external value change (via the `value` prop)
-  const previousChecked = usePrevious(checked)
-
-  // to decide which on is the source of "truth" in `controlledValue` (the last one to be changed is the true value)
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  const controlledChecked = useMemo(() => {
-    // If the `value` has changed, `value` takes precedence,
-    // otherwise we can use our current internal value
-    const nextControlledChecked = checked === previousChecked ? internalChecked : checked
-
-    return !isUndefinedWhenDisabled || !originalProps.disabled ? nextControlledChecked : undefined
-  }, [checked, internalChecked, isUndefinedWhenDisabled, originalProps.disabled, previousChecked])
-
   const controlledError = useMemo(() => normalizeString(error), [error])
-  const hasError = useMemo(() => Boolean(controlledError), [controlledError])
-  const key = getPseudoRandomString()
+  const hasError = Boolean(controlledError)
 
   const handleChange = useCallback(
     (_: ValueType | undefined, isChecked: boolean) => {
-      setInternalChecked(isChecked)
-
-      // We have to force the update since a state with the same value wouldn't re-render
-      // which generates conflicting behaviors
-      // when `value` prop is changed to a value that is equal to the current internal value
-      forceUpdate()
-
       if (onChange) {
         onChange(isChecked)
       }
     },
-    [forceUpdate, onChange]
+    [onChange]
   )
 
   useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, onChange)
 
   return (
-    <Field key={key} className="Field-Checkbox">
-      <StyledCheckbox
-        key={key}
-        checked={controlledChecked}
-        id={originalProps.name}
-        onChange={handleChange}
-        {...originalProps}
-      >
+    <Field className="Field-Checkbox">
+      <StyledCheckbox checked={checked} id={originalProps.name} onChange={handleChange} {...originalProps}>
         {label}
       </StyledCheckbox>
 

--- a/src/fields/MultiCheckbox.tsx
+++ b/src/fields/MultiCheckbox.tsx
@@ -4,7 +4,6 @@ import styled, { css } from 'styled-components'
 
 import { FieldError } from '../elements/FieldError'
 import { Fieldset } from '../elements/Fieldset'
-import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 import { normalizeString } from '../utils/normalizeString'
 
 import type { Option, OptionValueType } from '../types'
@@ -17,7 +16,6 @@ export type MultiCheckboxProps<OptionValue extends OptionValueType = any> = {
   isInline?: boolean | undefined
   isLabelHidden?: boolean | undefined
   isLight?: boolean | undefined
-  isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
   onChange?: ((nextValue: OptionValue[] | undefined) => Promisable<void>) | undefined
@@ -32,7 +30,6 @@ export function MultiCheckbox<OptionValue extends OptionValueType>({
   isInline = false,
   isLabelHidden = false,
   isLight = false,
-  isUndefinedWhenDisabled = false,
   label,
   name,
   onChange,
@@ -49,8 +46,6 @@ export function MultiCheckbox<OptionValue extends OptionValueType>({
     },
     [onChange]
   )
-
-  useFieldUndefineEffect(isUndefinedWhenDisabled && disabled, onChange)
 
   return (
     <Fieldset

--- a/src/fields/MultiRadio.tsx
+++ b/src/fields/MultiRadio.tsx
@@ -5,8 +5,6 @@ import styled, { css } from 'styled-components'
 
 import { FieldError } from '../elements/FieldError'
 import { Fieldset } from '../elements/Fieldset'
-import { useFieldControl } from '../hooks/useFieldControl'
-import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 import { useKey } from '../hooks/useKey'
 import { normalizeString } from '../utils/normalizeString'
 
@@ -20,7 +18,6 @@ export type MultiRadioProps<OptionValue extends OptionValueType = string> = {
   isInline?: boolean | undefined
   isLabelHidden?: boolean | undefined
   isLight?: boolean | undefined
-  isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
   onChange?: ((nextValue: OptionValue | undefined) => Promisable<void>) | undefined
@@ -34,18 +31,12 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
   isInline = false,
   isLabelHidden = false,
   isLight = false,
-  isUndefinedWhenDisabled = false,
   label,
   name,
   onChange,
   options,
   value
 }: MultiRadioProps<OptionValue>) {
-  const { controlledOnChange, controlledValue } = useFieldControl(value, onChange, {
-    disabled,
-    isUndefinedWhenDisabled
-  })
-
   const controlledError = useMemo(() => normalizeString(error), [error])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
   const key = useKey([disabled, name, value])
@@ -53,13 +44,12 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
   const handleChange = useCallback(
     (nextOptionValue: OptionValue, isChecked: boolean) => {
       const nextCheckedOptionValue = isChecked ? nextOptionValue : undefined
-
-      controlledOnChange(nextCheckedOptionValue)
+      if (onChange) {
+        onChange(nextCheckedOptionValue)
+      }
     },
-    [controlledOnChange]
+    [onChange]
   )
-
-  useFieldUndefineEffect(isUndefinedWhenDisabled && disabled, onChange)
 
   return (
     <Fieldset
@@ -75,7 +65,7 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
         {options.map(option => (
           <Radio
             key={JSON.stringify(option.value)}
-            checked={equals(option.value, controlledValue)}
+            checked={equals(option.value, value)}
             disabled={disabled}
             name={name}
             onChange={(_: any, isChecked: boolean) => handleChange(option.value, isChecked)}

--- a/src/fields/NumberInput.tsx
+++ b/src/fields/NumberInput.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import { Field } from '../elements/Field'
 import { FieldError } from '../elements/FieldError'
 import { Label } from '../elements/Label'
-import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 import { normalizeString } from '../utils/normalizeString'
 
 import type { InputNumberProps } from 'rsuite'
@@ -16,7 +15,6 @@ export type NumberInputProps = Omit<InputNumberProps, 'as' | 'defaultValue' | 'i
   isErrorMessageHidden?: boolean | undefined
   isLabelHidden?: boolean | undefined
   isLight?: boolean | undefined
-  isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
   onChange?: ((nextValue: number | undefined) => Promisable<void>) | undefined
@@ -28,7 +26,6 @@ export function NumberInput({
   isErrorMessageHidden = false,
   isLabelHidden = false,
   isLight = false,
-  isUndefinedWhenDisabled = false,
   label,
   onChange,
   value,
@@ -54,8 +51,6 @@ export function NumberInput({
     },
     [onChange]
   )
-
-  useFieldUndefineEffect(isUndefinedWhenDisabled && disabled, onChange)
 
   return (
     <Field className="Field-NumberInput">

--- a/src/fields/TextInput.tsx
+++ b/src/fields/TextInput.tsx
@@ -6,7 +6,6 @@ import { Field } from '../elements/Field'
 import { FieldError } from '../elements/FieldError'
 import { Label } from '../elements/Label'
 import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
-import { useKey } from '../hooks/useKey'
 import { normalizeString } from '../utils/normalizeString'
 
 import type { InputProps } from 'rsuite'
@@ -34,23 +33,16 @@ export function TextInput({
   value,
   ...originalProps
 }: TextInputProps) {
-  const controlledValue = useMemo(
-    () => (!isUndefinedWhenDisabled || !originalProps.disabled ? value : undefined),
-    [isUndefinedWhenDisabled, originalProps.disabled, value]
-  )
   const controlledError = useMemo(() => normalizeString(error), [error])
-  const hasError = useMemo(() => Boolean(controlledError), [controlledError])
-  const key = useKey([originalProps.disabled, originalProps.name])
+  const hasError = Boolean(controlledError)
 
   const handleChange = useCallback(
-    (nextValue: string | null) => {
+    (nextValue: string) => {
       if (!onChange) {
         return
       }
 
-      const normalizedNextValue = nextValue && nextValue.trim().length ? nextValue : undefined
-
-      onChange(normalizedNextValue)
+      onChange(nextValue)
     },
     [onChange]
   )
@@ -69,13 +61,13 @@ export function TextInput({
       </Label>
 
       <StyledInput
-        key={key}
         $hasError={hasError}
         $isLight={isLight}
         id={originalProps.name}
         onChange={handleChange}
         type="text"
-        value={controlledValue}
+        // handle undefined as a value for a controlled component
+        value={value || ''}
         {...originalProps}
       />
 

--- a/src/fields/TextInput.tsx
+++ b/src/fields/TextInput.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import { Field } from '../elements/Field'
 import { FieldError } from '../elements/FieldError'
 import { Label } from '../elements/Label'
-import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 import { normalizeString } from '../utils/normalizeString'
 
 import type { InputProps } from 'rsuite'
@@ -16,7 +15,6 @@ export type TextInputProps = Omit<InputProps, 'as' | 'defaultValue' | 'id' | 'on
   isErrorMessageHidden?: boolean | undefined
   isLabelHidden?: boolean | undefined
   isLight?: boolean | undefined
-  isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
   onChange?: ((nextValue: string | undefined) => Promisable<void>) | undefined
@@ -27,7 +25,6 @@ export function TextInput({
   isErrorMessageHidden = false,
   isLabelHidden = false,
   isLight = false,
-  isUndefinedWhenDisabled = false,
   label,
   onChange,
   value,
@@ -46,8 +43,6 @@ export function TextInput({
     },
     [onChange]
   )
-
-  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, onChange)
 
   return (
     <Field className="Field-TextInput">

--- a/src/fields/Textarea.tsx
+++ b/src/fields/Textarea.tsx
@@ -1,4 +1,4 @@
-import { BaseSyntheticEvent, useCallback, useMemo } from 'react'
+import { BaseSyntheticEvent, TextareaHTMLAttributes, useCallback, useMemo } from 'react'
 import { Input } from 'rsuite'
 import styled from 'styled-components'
 
@@ -10,7 +10,10 @@ import { normalizeString } from '../utils/normalizeString'
 import type { InputProps } from 'rsuite'
 import type { Promisable } from 'type-fest'
 
-export type TextareaProps = Omit<InputProps, 'defaultValue' | 'id' | 'onChange' | 'value'> & {
+export type TextareaProps = Omit<
+  InputProps & TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'defaultValue' | 'id' | 'onChange'
+> & {
   error?: string | undefined
   isErrorMessageHidden?: boolean | undefined
   isLabelHidden?: boolean | undefined
@@ -18,8 +21,6 @@ export type TextareaProps = Omit<InputProps, 'defaultValue' | 'id' | 'onChange' 
   label: string
   name: string
   onChange?: ((nextValue: string | undefined) => Promisable<void>) | undefined
-  rows?: number
-  value?: string | undefined
 }
 export function Textarea({
   error,

--- a/src/fields/Textarea.tsx
+++ b/src/fields/Textarea.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components'
 import { Field } from '../elements/Field'
 import { FieldError } from '../elements/FieldError'
 import { Label } from '../elements/Label'
-import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 import { normalizeString } from '../utils/normalizeString'
 
 import type { InputProps } from 'rsuite'
@@ -16,7 +15,6 @@ export type TextareaProps = Omit<InputProps, 'defaultValue' | 'id' | 'onChange' 
   isErrorMessageHidden?: boolean | undefined
   isLabelHidden?: boolean | undefined
   isLight?: boolean | undefined
-  isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
   onChange?: ((nextValue: string | undefined) => Promisable<void>) | undefined
@@ -28,7 +26,6 @@ export function Textarea({
   isErrorMessageHidden = false,
   isLabelHidden = false,
   isLight = false,
-  isUndefinedWhenDisabled = false,
   label,
   onChange,
   rows = 3,
@@ -48,8 +45,6 @@ export function Textarea({
     },
     [onChange]
   )
-
-  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, onChange)
 
   return (
     <Field className="Field-Textarea">

--- a/src/formiks/FormikCheckbox.tsx
+++ b/src/formiks/FormikCheckbox.tsx
@@ -1,30 +1,25 @@
 import { useField } from 'formik'
-import { useEffect, useMemo } from 'react'
+import { useMemo } from 'react'
 
 import { Checkbox } from '../fields/Checkbox'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { CheckboxProps } from '../fields/Checkbox'
 
-export type FormikCheckboxProps = Omit<CheckboxProps, 'checked' | 'error' | 'onChange'>
-export function FormikCheckbox({ name, ...originalProps }: FormikCheckboxProps) {
+export type FormikCheckboxProps = Omit<CheckboxProps, 'checked' | 'error' | 'onChange'> & {
+  isUndefinedWhenDisabled?: boolean | undefined
+}
+
+export function FormikCheckbox({ isUndefinedWhenDisabled = false, name, ...originalProps }: FormikCheckboxProps) {
   const [field, meta, helpers] = useField<boolean | undefined>(name)
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
 
   const isChecked = Boolean(field.value)
 
-  // A checkbox must initialize its Formik value on mount:
-  // it wouldn't make sense to keep it as `undefined` since `undefined` means `false` in the case of a checkbox
-  useEffect(
-    () => {
-      helpers.setValue(isChecked)
-    },
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    []
-  )
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <Checkbox checked={isChecked} error={meta.error} name={name} onChange={handleChange} {...originalProps} />
 }

--- a/src/formiks/FormikCoordinatesInput.tsx
+++ b/src/formiks/FormikCoordinatesInput.tsx
@@ -12,9 +12,12 @@ export function FormikCoordinatesInput({ name, ...originalProps }: FormikCoordin
   const [field, meta, helpers] = useField(name)
 
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const defaultValue = useMemo(() => field.value, [])
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => (nextCoordinates: number[] | undefined) => helpers.setValue(nextCoordinates), [])
+  const defaultValue = useMemo(() => field.value, [name])
+  const handleChange = useMemo(
+    () => (nextCoordinates: number[] | undefined) => helpers.setValue(nextCoordinates),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [name]
+  )
 
   return <CoordinatesInput defaultValue={defaultValue} error={meta.error} onChange={handleChange} {...originalProps} />
 }

--- a/src/formiks/FormikMultiCheckbox.tsx
+++ b/src/formiks/FormikMultiCheckbox.tsx
@@ -2,6 +2,7 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 
 import { MultiCheckbox } from '../fields/MultiCheckbox'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { MultiCheckboxProps } from '../fields/MultiCheckbox'
 import type { OptionValueType } from '../types'
@@ -9,8 +10,11 @@ import type { OptionValueType } from '../types'
 export type FormikMultiCheckboxProps<OptionValue extends OptionValueType = string> = Omit<
   MultiCheckboxProps<OptionValue>,
   'defaultValue' | 'error' | 'onChange'
->
+> & {
+  isUndefinedWhenDisabled?: boolean | undefined
+}
 export function FormikMultiCheckbox<OptionValue extends OptionValueType = string>({
+  isUndefinedWhenDisabled = false,
   name,
   ...originalProps
 }: FormikMultiCheckboxProps<OptionValue>) {
@@ -18,7 +22,9 @@ export function FormikMultiCheckbox<OptionValue extends OptionValueType = string
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
+
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <MultiCheckbox error={meta.error} name={name} onChange={handleChange} value={field.value} {...originalProps} />
 }

--- a/src/formiks/FormikMultiRadio.tsx
+++ b/src/formiks/FormikMultiRadio.tsx
@@ -2,6 +2,7 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 
 import { MultiRadio } from '../fields/MultiRadio'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { MultiRadioProps } from '../fields/MultiRadio'
 import type { OptionValueType } from '../types'
@@ -9,8 +10,9 @@ import type { OptionValueType } from '../types'
 export type FormikMultiRadioProps<OptionValue extends OptionValueType = string> = Omit<
   MultiRadioProps<OptionValue>,
   'error' | 'onChange' | 'value'
->
+> & { isUndefinedWhenDisabled?: boolean | undefined }
 export function FormikMultiRadio<OptionValue extends OptionValueType = string>({
+  isUndefinedWhenDisabled = false,
   name,
   ...originalProps
 }: FormikMultiRadioProps<OptionValue>) {
@@ -18,7 +20,9 @@ export function FormikMultiRadio<OptionValue extends OptionValueType = string>({
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
+
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <MultiRadio error={meta.error} name={name} onChange={handleChange} value={field.value} {...originalProps} />
 }

--- a/src/formiks/FormikMultiSelect.tsx
+++ b/src/formiks/FormikMultiSelect.tsx
@@ -2,6 +2,7 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 
 import { MultiSelect } from '../fields/MultiSelect'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { MultiSelectProps } from '../fields/MultiSelect'
 import type { OptionValueType } from '../types'
@@ -9,8 +10,10 @@ import type { OptionValueType } from '../types'
 export type FormikMultiSelectProps<OptionValue extends OptionValueType = string> = Omit<
   MultiSelectProps<OptionValue>,
   'error' | 'onChange' | 'value'
->
+> & { isUndefinedWhenDisabled?: boolean | undefined }
+
 export function FormikMultiSelect<OptionValue extends OptionValueType = string>({
+  isUndefinedWhenDisabled = false,
   name,
   ...originalProps
 }: FormikMultiSelectProps<OptionValue>) {
@@ -18,7 +21,9 @@ export function FormikMultiSelect<OptionValue extends OptionValueType = string>(
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
+
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <MultiSelect error={meta.error} name={name} onChange={handleChange} value={field.value} {...originalProps} />
 }

--- a/src/formiks/FormikNumberInput.tsx
+++ b/src/formiks/FormikNumberInput.tsx
@@ -2,16 +2,22 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 
 import { NumberInput } from '../fields/NumberInput'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { NumberInputProps } from '../fields/NumberInput'
 
-export type FormikNumberInputProps = Omit<NumberInputProps, 'error' | 'onChange' | 'value'>
-export function FormikNumberInput({ name, ...originalProps }: FormikNumberInputProps) {
+export type FormikNumberInputProps = Omit<NumberInputProps, 'error' | 'onChange' | 'value'> & {
+  isUndefinedWhenDisabled?: boolean | undefined
+}
+
+export function FormikNumberInput({ isUndefinedWhenDisabled = false, name, ...originalProps }: FormikNumberInputProps) {
   const [field, meta, helpers] = useField(name)
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
+
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <NumberInput error={meta.error} name={name} onChange={handleChange} value={field.value} {...originalProps} />
 }

--- a/src/formiks/FormikSelect.tsx
+++ b/src/formiks/FormikSelect.tsx
@@ -2,6 +2,7 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 
 import { Select } from '../fields/Select'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { SelectProps } from '../fields/Select'
 import type { OptionValueType } from '../types'
@@ -9,8 +10,12 @@ import type { OptionValueType } from '../types'
 export type FormikSelectProps<OptionValue extends OptionValueType = string> = Omit<
   SelectProps<OptionValue>,
   'error' | 'onChange' | 'value'
->
+> & {
+  isUndefinedWhenDisabled?: boolean | undefined
+}
+
 export function FormikSelect<OptionValue extends OptionValueType = string>({
+  isUndefinedWhenDisabled = false,
   name,
   ...originalProps
 }: FormikSelectProps<OptionValue>) {
@@ -18,7 +23,9 @@ export function FormikSelect<OptionValue extends OptionValueType = string>({
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
+
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <Select error={meta.error} name={name} onChange={handleChange} value={field.value} {...originalProps} />
 }

--- a/src/formiks/FormikTextInput.tsx
+++ b/src/formiks/FormikTextInput.tsx
@@ -2,16 +2,21 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 
 import { TextInput } from '../fields/TextInput'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { TextInputProps } from '../fields/TextInput'
 
-export type FormikTextInputProps = Omit<TextInputProps, 'error' | 'onChange' | 'value'>
-export function FormikTextInput({ name, ...originalProps }: FormikTextInputProps) {
+export type FormikTextInputProps = Omit<TextInputProps, 'error' | 'onChange' | 'value'> & {
+  isUndefinedWhenDisabled?: boolean | undefined
+}
+export function FormikTextInput({ isUndefinedWhenDisabled = false, name, ...originalProps }: FormikTextInputProps) {
   const [field, meta, helpers] = useField(name)
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
+
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <TextInput error={meta.error} name={name} onChange={handleChange} value={field.value} {...originalProps} />
 }

--- a/src/formiks/FormikTextarea.tsx
+++ b/src/formiks/FormikTextarea.tsx
@@ -2,16 +2,22 @@ import { useField } from 'formik'
 import { useMemo } from 'react'
 
 import { Textarea } from '../fields/Textarea'
+import { useFieldUndefineEffect } from '../hooks/useFieldUndefineEffect'
 
 import type { TextareaProps } from '../fields/Textarea'
 
-export type FormikTextareaProps = Omit<TextareaProps, 'error' | 'onChange' | 'value'>
-export function FormikTextarea({ name, ...originalProps }: FormikTextareaProps) {
+export type FormikTextareaProps = Omit<TextareaProps, 'error' | 'onChange' | 'value'> & {
+  isUndefinedWhenDisabled?: boolean | undefined
+}
+
+export function FormikTextarea({ isUndefinedWhenDisabled = false, name, ...originalProps }: FormikTextareaProps) {
   const [field, meta, helpers] = useField(name)
 
   // We don't want to trigger infinite re-rendering since `helpers.setValue` changes after each rendering
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const handleChange = useMemo(() => helpers.setValue, [])
+  const handleChange = useMemo(() => helpers.setValue, [name])
+
+  useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, handleChange)
 
   return <Textarea error={meta.error} name={name} onChange={handleChange} value={field.value} {...originalProps} />
 }

--- a/stories/fields/Checkbox.stories.tsx
+++ b/stories/fields/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Output } from '../../.storybook/components/Output'
 import { generateStoryDecorator } from '../../.storybook/components/StoryDecorator'
@@ -26,13 +26,16 @@ export default {
 }
 
 export function _Checkbox(props: CheckboxProps) {
-  const [outputValue, setOutputValue] = useState<boolean | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState<boolean | undefined>(props.checked)
+  useEffect(() => {
+    setOutputValue(props.checked)
+  }, [props.checked])
 
   return (
     <>
-      <Checkbox {...props} onChange={setOutputValue} />
+      <Checkbox {...props} checked={outputValue} onChange={setOutputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }

--- a/stories/fields/MultiCheckbox.stories.tsx
+++ b/stories/fields/MultiCheckbox.stories.tsx
@@ -16,7 +16,7 @@ const args: MultiCheckboxProps = {
   label: 'Pick some options',
   name: 'myMultiCheckbox',
   options: [
-    { label: 'First Option', value: { is: 'object' } },
+    { label: 'First Option', value: 'FIRST_OPTION' },
     { label: 'Second Option', value: 'SECOND_OPTION' },
     { label: 'Third Option', value: 'THIRD_OPTION' },
     { label: 'A Very Very Long Option', value: 'A_VERY_VERY_LONG_OPTION' }

--- a/stories/fields/MultiCheckbox.stories.tsx
+++ b/stories/fields/MultiCheckbox.stories.tsx
@@ -16,7 +16,7 @@ const args: MultiCheckboxProps = {
   label: 'Pick some options',
   name: 'myMultiCheckbox',
   options: [
-    { label: 'First Option', value: 'FIRST_OPTION' },
+    { label: 'First Option', value: { is: 'object' } },
     { label: 'Second Option', value: 'SECOND_OPTION' },
     { label: 'Third Option', value: 'THIRD_OPTION' },
     { label: 'A Very Very Long Option', value: 'A_VERY_VERY_LONG_OPTION' }
@@ -45,13 +45,13 @@ export default {
 }
 
 export function _MultiCheckbox(props: MultiCheckboxProps) {
-  const [outputValue, setOutputValue] = useState<string[] | undefined | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState<any>(props.value)
 
   return (
     <>
-      <MultiCheckbox {...props} onChange={setOutputValue} />
+      <MultiCheckbox {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }

--- a/stories/fields/MultiRadio.stories.tsx
+++ b/stories/fields/MultiRadio.stories.tsx
@@ -45,13 +45,13 @@ export default {
 }
 
 export function _MultiRadio(props: MultiRadioProps) {
-  const [outputValue, setOutputValue] = useState<string | undefined | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState(props.value)
 
   return (
     <>
-      <MultiRadio {...props} onChange={setOutputValue} />
+      <MultiRadio {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }

--- a/stories/fields/MultiSelect.stories.tsx
+++ b/stories/fields/MultiSelect.stories.tsx
@@ -57,7 +57,7 @@ export function _MultiSelect(props: MultiSelectProps) {
 
   const [isNewWindowOpen, setIsNewWindowOpen] = useState(false)
   const [isNewWindowFirstLoad, setIsNewWindowFirstLoad] = useState(true)
-  const [outputValue, setOutputValue] = useState<string[] | undefined | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState<string[] | undefined>()
 
   const { forceUpdate } = useForceUpdate()
 
@@ -84,9 +84,9 @@ export function _MultiSelect(props: MultiSelectProps) {
         </Button>
       </NewWindowButtonBox>
 
-      <MultiSelect {...props} onChange={setOutputValue} />
+      <MultiSelect {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
 
       {isNewWindowOpen && (
         <NewWindow isStoryBook onUnload={() => setIsNewWindowOpen(false)}>

--- a/stories/fields/MultiSelect.stories.tsx
+++ b/stories/fields/MultiSelect.stories.tsx
@@ -57,7 +57,7 @@ export function _MultiSelect(props: MultiSelectProps) {
 
   const [isNewWindowOpen, setIsNewWindowOpen] = useState(false)
   const [isNewWindowFirstLoad, setIsNewWindowFirstLoad] = useState(true)
-  const [outputValue, setOutputValue] = useState<string[] | undefined>()
+  const [outputValue, setOutputValue] = useState(props.value)
 
   const { forceUpdate } = useForceUpdate()
 

--- a/stories/fields/NumberInput.stories.tsx
+++ b/stories/fields/NumberInput.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Output } from '../../.storybook/components/Output'
 import { generateStoryDecorator } from '../../.storybook/components/StoryDecorator'
@@ -40,13 +40,17 @@ export default {
 }
 
 export function _NumberInput(props: NumberInputProps) {
-  const [outputValue, setOutputValue] = useState<number | undefined | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState<number | undefined>(props.value)
+
+  useEffect(() => {
+    setOutputValue(props.value)
+  }, [props.value])
 
   return (
     <>
-      <NumberInput {...props} onChange={setOutputValue} />
+      <NumberInput {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }

--- a/stories/fields/Select.stories.tsx
+++ b/stories/fields/Select.stories.tsx
@@ -57,7 +57,7 @@ export function _Select(props: SelectProps) {
 
   const [isNewWindowOpen, setIsNewWindowOpen] = useState(false)
   const [isNewWindowFirstLoad, setIsNewWindowFirstLoad] = useState(true)
-  const [outputValue, setOutputValue] = useState<any>('∅')
+  const [outputValue, setOutputValue] = useState(props.value)
 
   const { forceUpdate } = useForceUpdate()
 

--- a/stories/fields/TextInput.stories.tsx
+++ b/stories/fields/TextInput.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Output } from '../../.storybook/components/Output'
 import { generateStoryDecorator } from '../../.storybook/components/StoryDecorator'
@@ -41,13 +41,17 @@ export default {
 }
 
 export function _TextInput(props: TextInputProps) {
-  const [outputValue, setOutputValue] = useState<string | undefined | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState<string | undefined>(props.value)
+
+  useEffect(() => {
+    setOutputValue(props.value)
+  }, [props.value])
 
   return (
     <>
-      <TextInput {...props} onChange={setOutputValue} />
+      <TextInput {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }

--- a/stories/fields/Textarea.stories.tsx
+++ b/stories/fields/Textarea.stories.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 
 import { Output } from '../../.storybook/components/Output'
 import { generateStoryDecorator } from '../../.storybook/components/StoryDecorator'
@@ -15,6 +15,7 @@ const args: TextareaProps = {
   label: 'A textarea',
   name: 'myTextarea',
   placeholder: 'A textarea placeholder',
+  rows: 2,
   value: undefined
 }
 
@@ -41,13 +42,16 @@ export default {
 }
 
 export function _Textarea(props: TextareaProps) {
-  const [outputValue, setOutputValue] = useState<string | undefined | '∅'>('∅')
+  const [outputValue, setOutputValue] = useState<string | undefined>(props.value)
+  useEffect(() => {
+    setOutputValue(props.value)
+  }, [props.value])
 
   return (
     <>
-      <Textarea {...props} onChange={setOutputValue} />
+      <Textarea {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }

--- a/stories/fields/Textarea.stories.tsx
+++ b/stories/fields/Textarea.stories.tsx
@@ -42,7 +42,7 @@ export default {
 }
 
 export function _Textarea(props: TextareaProps) {
-  const [outputValue, setOutputValue] = useState<string | undefined>(props.value)
+  const [outputValue, setOutputValue] = useState(props.value)
   useEffect(() => {
     setOutputValue(props.value)
   }, [props.value])

--- a/stories/tests/all_formiks.stories.tsx
+++ b/stories/tests/all_formiks.stories.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 
 import { Output } from '../../.storybook/components/Output'
 import {
+  Checkbox,
   FormikCheckbox,
   FormikEffect,
   FormikMultiCheckbox,
@@ -26,169 +27,227 @@ export default {
 
 export function Template() {
   const [outputValue, setOutputValue] = useState<any>('∅')
+  const [isReadOnly, setIsReadOnly] = useState(false)
+  const [undefinedWhenDisabled, setUndefinedWhenDisabled] = useState(false)
 
   return (
-    <Formik initialValues={{}} onSubmit={noop}>
-      <>
-        <FormikEffect onChange={setOutputValue} />
+    <>
+      <Checkbox checked={isReadOnly} label="Read only ?" name="isReadOnly" onChange={setIsReadOnly} />
+      <Checkbox
+        checked={undefinedWhenDisabled}
+        label="set to undefined when field is disabled"
+        name="undefinedWhenDisabled"
+        onChange={setUndefinedWhenDisabled}
+      />
+      <Formik initialValues={{}} onSubmit={noop}>
+        <>
+          <FormikEffect onChange={setOutputValue} />
 
-        <h1>Test Page</h1>
+          <h1>Test Page</h1>
 
-        <div>
-          <FormikTextInput label="Text input" name="textInput" />
-          <hr />
-          <FormikTextInput isLabelHidden label="Text input with hidden label" name="textInputWithHiddenLabel" />
+          <div>
+            <FormikTextInput
+              disabled={isReadOnly}
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Text input"
+              name="textInput"
+            />
+            <hr />
+            <FormikTextInput
+              disabled={isReadOnly}
+              isLabelHidden
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Text input with hidden label"
+              name="textInputWithHiddenLabel"
+            />
 
-          <hr />
-          <FormikTextarea label="Textarea" name="textarea" />
-          <hr />
-          <FormikTextarea isLabelHidden label="Textarea with hidden label" name="textareaWithHiddenLabel" />
+            <hr />
+            <FormikTextarea
+              disabled={isReadOnly}
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Textarea"
+              name="textarea"
+            />
+            <hr />
+            <FormikTextarea
+              disabled={isReadOnly}
+              isLabelHidden
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Textarea with hidden label"
+              name="textareaWithHiddenLabel"
+            />
 
-          <hr />
-          <FormikCheckbox label="Checkbox" name="checkbox" />
+            <hr />
+            <FormikCheckbox
+              disabled={isReadOnly}
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Checkbox"
+              name="checkbox"
+            />
 
-          <hr />
-          <FormikSelect
-            label="Select"
-            name="select"
-            options={[
-              { label: 'First select option', value: 'FIRST_SELECT_OPTION' },
-              { label: 'Second select option', value: 'SECOND_SELECT_OPTION' },
-              { label: 'Third select option', value: 'THIRD_SELECT_OPTION' }
-            ]}
-          />
-          <hr />
-          <FormikSelect
-            label="Select with search input"
-            name="selectWithSearchInput"
-            options={new Array(50).fill(undefined).map((_, index) => ({
-              label: `Select with search input option ${String(index + 1).padStart(2, '0')}`,
-              value: `SELECT_WITH_SEARCH_INPUT_OPTION_${String(index + 1).padStart(2, '0')}`
-            }))}
-            searchable
-          />
-          <hr />
-          <FormikSelect
-            isLabelHidden
-            label="Select with hidden label"
-            name="selectWithHiddenLabel"
-            options={[
-              { label: 'First select with hidden label option', value: 'FIRST_SELECT_WITH_HIDDEN_LABEL_OPTION' },
-              { label: 'Second select with hidden label option', value: 'SECOND_SELECT_WITH_HIDDEN_LABEL_OPTION' },
-              { label: 'Third select with hidden label option', value: 'THIRD_SELECT_WITH_HIDDEN_LABEL_OPTION' }
-            ]}
-          />
+            <hr />
+            <FormikSelect
+              disabled={isReadOnly}
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Select"
+              name="select"
+              options={[
+                { label: 'First select option', value: 'FIRST_SELECT_OPTION' },
+                { label: 'Second select option', value: 'SECOND_SELECT_OPTION' },
+                { label: 'Third select option', value: 'THIRD_SELECT_OPTION' }
+              ]}
+            />
+            <hr />
+            <FormikSelect
+              disabled={isReadOnly}
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Select with search input"
+              name="selectWithSearchInput"
+              options={new Array(50).fill(undefined).map((_, index) => ({
+                label: `Select with search input option ${String(index + 1).padStart(2, '0')}`,
+                value: `SELECT_WITH_SEARCH_INPUT_OPTION_${String(index + 1).padStart(2, '0')}`
+              }))}
+              searchable
+            />
+            <hr />
+            <FormikSelect
+              disabled={isReadOnly}
+              isLabelHidden
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Select with hidden label"
+              name="selectWithHiddenLabel"
+              options={[
+                { label: 'First select with hidden label option', value: 'FIRST_SELECT_WITH_HIDDEN_LABEL_OPTION' },
+                { label: 'Second select with hidden label option', value: 'SECOND_SELECT_WITH_HIDDEN_LABEL_OPTION' },
+                { label: 'Third select with hidden label option', value: 'THIRD_SELECT_WITH_HIDDEN_LABEL_OPTION' }
+              ]}
+            />
 
-          <hr />
-          <FormikMultiSelect
-            label="Multi select"
-            name="multiSelect"
-            options={[
-              { label: 'First multi select option', value: 'FIRST_MULTI_SELECT_OPTION' },
-              { label: 'Second multi select option', value: 'SECOND_MULTI_SELECT_OPTION' },
-              { label: 'Third multi select option', value: 'THIRD_MULTI_SELECT_OPTION' }
-            ]}
-          />
-          <hr />
-          <FormikMultiSelect
-            label="Multi select with search input"
-            name="multiSelectWithSearchInput"
-            options={new Array(50).fill(undefined).map((_, index) => ({
-              label: `Multi select with search input option ${String(index + 1).padStart(2, '0')}`,
-              value: `MULTI_SELECT_WITH_SEARCH_INPUT_OPTION_${String(index + 1).padStart(2, '0')}`
-            }))}
-            searchable
-          />
-          <hr />
-          <FormikMultiSelect
-            isLabelHidden
-            label="Multi select with hidden label"
-            name="multiSelectWithHiddenLabel"
-            options={[
-              {
-                label: 'First multi select with hidden label option',
-                value: 'FIRST_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION'
-              },
-              {
-                label: 'Second multi select with hidden label option',
-                value: 'SECOND_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION'
-              },
-              {
-                label: 'Third multi select with hidden label option',
-                value: 'THIRD_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION'
-              }
-            ]}
-          />
+            <hr />
+            <FormikMultiSelect
+              disabled={isReadOnly}
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Multi select"
+              name="multiSelect"
+              options={[
+                { label: 'First multi select option', value: 'FIRST_MULTI_SELECT_OPTION' },
+                { label: 'Second multi select option', value: 'SECOND_MULTI_SELECT_OPTION' },
+                { label: 'Third multi select option', value: 'THIRD_MULTI_SELECT_OPTION' }
+              ]}
+            />
+            <hr />
+            <FormikMultiSelect
+              disabled={isReadOnly}
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Multi select with search input"
+              name="multiSelectWithSearchInput"
+              options={new Array(50).fill(undefined).map((_, index) => ({
+                label: `Multi select with search input option ${String(index + 1).padStart(2, '0')}`,
+                value: `MULTI_SELECT_WITH_SEARCH_INPUT_OPTION_${String(index + 1).padStart(2, '0')}`
+              }))}
+              searchable
+            />
+            <hr />
+            <FormikMultiSelect
+              disabled={isReadOnly}
+              isLabelHidden
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Multi select with hidden label"
+              name="multiSelectWithHiddenLabel"
+              options={[
+                {
+                  label: 'First multi select with hidden label option',
+                  value: 'FIRST_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION'
+                },
+                {
+                  label: 'Second multi select with hidden label option',
+                  value: 'SECOND_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION'
+                },
+                {
+                  label: 'Third multi select with hidden label option',
+                  value: 'THIRD_MULTI_SELECT_WITH_HIDDEN_LABEL_OPTION'
+                }
+              ]}
+            />
 
-          <hr />
-          <FormikMultiCheckbox
-            isInline
-            label="Multi checkbox"
-            name="multiCheckbox"
-            options={[
-              { label: 'First multi checkbox option', value: 'FIRST_MULTI_CHECKBOX_OPTION' },
-              { label: 'Second multi checkbox option', value: 'SECOND_MULTI_CHECKBOX_OPTION' },
-              { label: 'Third multi checkbox option', value: 'THIRD_MULTI_CHECKBOX_OPTION' }
-            ]}
-          />
-          <hr />
-          <FormikMultiCheckbox
-            isInline
-            isLabelHidden
-            label="Multi checkbox with hidden label"
-            name="multiCheckboxWithHiddenLabel"
-            options={[
-              {
-                label: 'First multi checkbox with hidden label option',
-                value: 'FIRST_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
-              },
-              {
-                label: 'Second multi checkbox with hidden label option',
-                value: 'SECOND_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
-              },
-              {
-                label: 'Third multi checkbox with hidden label option',
-                value: 'THIRD_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
-              }
-            ]}
-          />
+            <hr />
+            <FormikMultiCheckbox
+              disabled={isReadOnly}
+              isInline
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Multi checkbox"
+              name="multiCheckbox"
+              options={[
+                { label: 'First multi checkbox option', value: 'FIRST_MULTI_CHECKBOX_OPTION' },
+                { label: 'Second multi checkbox option', value: 'SECOND_MULTI_CHECKBOX_OPTION' },
+                { label: 'Third multi checkbox option', value: 'THIRD_MULTI_CHECKBOX_OPTION' }
+              ]}
+            />
+            <hr />
+            <FormikMultiCheckbox
+              disabled={isReadOnly}
+              isInline
+              isLabelHidden
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Multi checkbox with hidden label"
+              name="multiCheckboxWithHiddenLabel"
+              options={[
+                {
+                  label: 'First multi checkbox with hidden label option',
+                  value: 'FIRST_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
+                },
+                {
+                  label: 'Second multi checkbox with hidden label option',
+                  value: 'SECOND_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
+                },
+                {
+                  label: 'Third multi checkbox with hidden label option',
+                  value: 'THIRD_MULTI_CHECKBOX_WITH_HIDDEN_LABEL_OPTION'
+                }
+              ]}
+            />
 
-          <hr />
-          <FormikMultiRadio
-            isInline
-            label="Multi radio"
-            name="multiRadio"
-            options={[
-              { label: 'First multi radio option', value: 'FIRST_MULTI_RADIO_OPTION' },
-              { label: 'Second multi radio option', value: 'SECOND_MULTI_RADIO_OPTION' },
-              { label: 'Third multi radio option', value: 'THIRD_MULTI_RADIO_OPTION' }
-            ]}
-          />
-          <hr />
-          <FormikMultiRadio
-            isInline
-            isLabelHidden
-            label="Multi radio with hidden label"
-            name="multiRadioWithHiddenLabel"
-            options={[
-              {
-                label: 'First multi radio with hidden label option',
-                value: 'FIRST_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
-              },
-              {
-                label: 'Second multi radio with hidden label option',
-                value: 'SECOND_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
-              },
-              {
-                label: 'Third multi radio with hidden label option',
-                value: 'THIRD_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
-              }
-            ]}
-          />
-        </div>
+            <hr />
+            <FormikMultiRadio
+              disabled={isReadOnly}
+              isInline
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Multi radio"
+              name="multiRadio"
+              options={[
+                { label: 'First multi radio option', value: 'FIRST_MULTI_RADIO_OPTION' },
+                { label: 'Second multi radio option', value: 'SECOND_MULTI_RADIO_OPTION' },
+                { label: 'Third multi radio option', value: 'THIRD_MULTI_RADIO_OPTION' }
+              ]}
+            />
+            <hr />
+            <FormikMultiRadio
+              disabled={isReadOnly}
+              isInline
+              isLabelHidden
+              isUndefinedWhenDisabled={undefinedWhenDisabled}
+              label="Multi radio with hidden label"
+              name="multiRadioWithHiddenLabel"
+              options={[
+                {
+                  label: 'First multi radio with hidden label option',
+                  value: 'FIRST_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
+                },
+                {
+                  label: 'Second multi radio with hidden label option',
+                  value: 'SECOND_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
+                },
+                {
+                  label: 'Third multi radio with hidden label option',
+                  value: 'THIRD_MULTI_RADIO_WITH_HIDDEN_LABEL_OPTION'
+                }
+              ]}
+            />
+          </div>
 
-        {outputValue !== '∅' && <Output value={outputValue} />}
-      </>
-    </Formik>
+          {outputValue !== '∅' && <Output value={outputValue} />}
+        </>
+      </Formik>
+    </>
   )
 }

--- a/stories/tests/multi_select_with_number_options.stories.tsx
+++ b/stories/tests/multi_select_with_number_options.stories.tsx
@@ -36,13 +36,13 @@ export default {
 }
 
 export function _MultiSelect(props: MultiSelectProps) {
-  const [outputValue, setOutputValue] = useState<any>('∅')
+  const [outputValue, setOutputValue] = useState<any>(undefined)
 
   return (
     <>
-      <MultiSelect {...props} onChange={setOutputValue} />
+      <MultiSelect {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }

--- a/stories/tests/multi_select_with_object_options.stories.tsx
+++ b/stories/tests/multi_select_with_object_options.stories.tsx
@@ -40,13 +40,13 @@ export default {
 }
 
 export function _MultiSelect(props: MultiSelectProps) {
-  const [outputValue, setOutputValue] = useState<any>('∅')
+  const [outputValue, setOutputValue] = useState<any>(undefined)
 
   return (
     <>
-      <MultiSelect {...props} onChange={setOutputValue} />
+      <MultiSelect {...props} onChange={setOutputValue} value={outputValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+      <Output value={outputValue} />
     </>
   )
 }


### PR DESCRIPTION
Proposal for controlled components:
- remove internal state when possible
- remove memoization overhead for basic evaluations (i.e. casting to boolean `useMemo(() => Boolean(controlledError), [controlledError])`)
- controlled components shouldn't need passing a custom key
- use rsuite handlers instead of creating new ones

## Related Pull Requests 
https://github.com/MTES-MCT/monitor-ui/pull/345

## Preview URL

https://637e01cf5934a2ae881ccc9d-htmpfdmazd.chromatic.com/
