### PR TITLE
ci(github): limit workflow run event to e2e in Dependabot auto-merge workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,5 @@
 ## Preview URL
 
 <!-- AUTOFILLED_PREVIEW_URL -->
-
 _Waiting for deployment..._
-
 <!-- AUTOFILLED_PREVIEW_URL -->

--- a/.github/workflows/merge_dependabot_pull_request.yml
+++ b/.github/workflows/merge_dependabot_pull_request.yml
@@ -5,7 +5,9 @@ on:
     branches:
       - 'dependabot/**'
   workflow_run:
-    workflows: [Check, E2E, Preview]
+    # workflows: [Check, E2E, Preview]
+    # Because of https://github.com/orgs/community/discussions/16059
+    workflows: [E2E]
     types: [completed]
 
 jobs:


### PR DESCRIPTION
## Related Pull Requests & Issues

None

## Preview URL

<!-- https://637e01cf5934a2ae881ccc9d-cthidcxkdk.chromatic.com/ -->

_Waiting for deployment..._

<!-- AUTOFILLED_PREVIEW_URL -->
