### PR TITLE
ci(github): limit Dependabot auto-merge workflow to Dependanbot branches (bis)

### DIFF
--- a/.github/workflows/merge_dependabot_pull_request.yml
+++ b/.github/workflows/merge_dependabot_pull_request.yml
@@ -11,7 +11,7 @@ jobs:
   merge:
     name: Merge Dependabot Pull Request
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'dependabot/') && github.event.workflow_run.conclusion == 'success' }}
+    if: ${{ startsWith(github.ref, 'refs/heads/dependabot/') && github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Merge pull request
         uses: pascalgn/automerge-action@v0.15.6


### PR DESCRIPTION
## Related Pull Requests & Issues

None

## Preview URL

<!-- https://637e01cf5934a2ae881ccc9d-elkgfuewhn.chromatic.com/ -->
_Waiting for deployment..._
<!-- AUTOFILLED_PREVIEW_URL -->
