### PR TITLE
fix(fields)!: move style prop passing to container level

### DIFF
--- a/src/fields/Checkbox.tsx
+++ b/src/fields/Checkbox.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { useCallback, useMemo } from 'react'
+import classnames from 'classnames'
+import { useCallback, useMemo, type CSSProperties } from 'react'
 import { Checkbox as RsuiteCheckbox } from 'rsuite'
 import styled from 'styled-components'
 
@@ -16,22 +17,27 @@ import type { Promisable } from 'type-fest'
 
 export type CheckboxProps = Omit<RsuiteCheckboxProps, 'as' | 'checked' | 'defaultChecked' | 'id' | 'onChange'> & {
   checked?: boolean | undefined
+  className?: string | undefined
   error?: string | undefined
   isErrorMessageHidden?: boolean | undefined
   isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
   onChange?: ((isCheched: boolean) => Promisable<void>) | undefined
+  style?: CSSProperties | undefined
 }
 export function Checkbox({
   checked = false,
+  className,
   error,
   isErrorMessageHidden = false,
   isUndefinedWhenDisabled = false,
   label,
   onChange,
+  style,
   ...originalProps
 }: CheckboxProps) {
+  const controlledClassName = useMemo(() => classnames('Field-Checkbox', className), [className])
   const controlledError = useMemo(() => normalizeString(error), [error])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
   const key = getPseudoRandomString()
@@ -50,7 +56,7 @@ export function Checkbox({
   useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, onChange)
 
   return (
-    <Field className="Field-Checkbox">
+    <Field className={controlledClassName} style={style}>
       <StyledCheckbox key={key} checked={checked} id={originalProps.name} onChange={handleChange} {...originalProps}>
         {label}
       </StyledCheckbox>

--- a/src/fields/DatePicker/index.tsx
+++ b/src/fields/DatePicker/index.tsx
@@ -112,6 +112,7 @@ export function DatePicker({
   label,
   minutesRange = 15,
   onChange,
+  style,
   withTime = false,
   ...nativeProps
 }: DatePickerProps) {
@@ -327,6 +328,7 @@ export function DatePicker({
       hasError={hasError}
       isLegendHidden={isLabelHidden}
       legend={label}
+      style={style}
       {...nativeProps}
     >
       <Box ref={boxRef} $hasError={hasError} $isDisabled={disabled}>

--- a/src/fields/DateRangePicker/index.tsx
+++ b/src/fields/DateRangePicker/index.tsx
@@ -121,6 +121,7 @@ export function DateRangePicker({
   label,
   minutesRange = 15,
   onChange,
+  style,
   withTime = false,
   ...nativeProps
 }: DateRangePickerProps) {
@@ -450,6 +451,7 @@ export function DateRangePicker({
       hasError={hasError}
       isLegendHidden={isLabelHidden}
       legend={label}
+      style={style}
       {...nativeProps}
     >
       <Box $hasError={hasError} $isDisabled={disabled}>

--- a/src/fields/MultiCheckbox.tsx
+++ b/src/fields/MultiCheckbox.tsx
@@ -1,5 +1,6 @@
+import classnames from 'classnames'
 import { equals, includes, reject } from 'ramda'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, type CSSProperties } from 'react'
 import styled, { css } from 'styled-components'
 
 import { Checkbox } from './Checkbox'
@@ -13,6 +14,7 @@ import type { Option, OptionValueType } from '../types'
 import type { Promisable } from 'type-fest'
 
 export type MultiCheckboxProps<OptionValue extends OptionValueType = string> = {
+  className?: string | undefined
   disabled?: boolean | undefined
   error?: string | undefined
   isErrorMessageHidden?: boolean | undefined
@@ -24,9 +26,11 @@ export type MultiCheckboxProps<OptionValue extends OptionValueType = string> = {
   name: string
   onChange?: ((nextValue: OptionValue[] | undefined) => Promisable<void>) | undefined
   options: Option<OptionValue>[]
+  style?: CSSProperties | undefined
   value?: OptionValue[] | undefined
 }
 export function MultiCheckbox<OptionValue extends OptionValueType = string>({
+  className,
   disabled = false,
   error,
   isErrorMessageHidden = false,
@@ -38,8 +42,10 @@ export function MultiCheckbox<OptionValue extends OptionValueType = string>({
   name,
   onChange,
   options,
+  style,
   value
 }: MultiCheckboxProps<OptionValue>) {
+  const controlledClassName = useMemo(() => classnames('Field-MultiCheckbox', className), [className])
   const controlledError = useMemo(() => normalizeString(error), [error])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
   const key = useKey([value, disabled, name])
@@ -65,12 +71,13 @@ export function MultiCheckbox<OptionValue extends OptionValueType = string>({
 
   return (
     <Fieldset
-      className="Field-MultiCheckbox"
+      className={controlledClassName}
       disabled={disabled}
       hasError={hasError}
       isLegendHidden={isLabelHidden}
       isLight={isLight}
       legend={label}
+      style={style}
     >
       <ChecboxesBox key={key} $hasError={hasError} $isInline={isInline}>
         {options.map((option, index) => (

--- a/src/fields/MultiRadio.tsx
+++ b/src/fields/MultiRadio.tsx
@@ -1,5 +1,6 @@
+import classnames from 'classnames'
 import { equals } from 'ramda'
-import { useCallback, useMemo } from 'react'
+import { useCallback, useMemo, type CSSProperties } from 'react'
 import { Radio } from 'rsuite'
 import styled, { css } from 'styled-components'
 
@@ -13,6 +14,7 @@ import type { Option, OptionValueType } from '../types'
 import type { Promisable } from 'type-fest'
 
 export type MultiRadioProps<OptionValue extends OptionValueType = string> = {
+  className?: string | undefined
   disabled?: boolean | undefined
   error?: string | undefined
   isErrorMessageHidden?: boolean | undefined
@@ -24,9 +26,11 @@ export type MultiRadioProps<OptionValue extends OptionValueType = string> = {
   name: string
   onChange?: ((nextValue: OptionValue | undefined) => Promisable<void>) | undefined
   options: Option<OptionValue>[]
+  style?: CSSProperties | undefined
   value?: OptionValue | undefined
 }
 export function MultiRadio<OptionValue extends OptionValueType = string>({
+  className,
   disabled = false,
   error,
   isErrorMessageHidden = false,
@@ -38,8 +42,10 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
   name,
   onChange,
   options,
+  style,
   value
 }: MultiRadioProps<OptionValue>) {
+  const controlledClassName = useMemo(() => classnames('Field-MultiRadio', className), [className])
   const controlledError = useMemo(() => normalizeString(error), [error])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
   const key = useKey([value, disabled, name])
@@ -61,12 +67,13 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
 
   return (
     <Fieldset
-      className="Field-MultiRadio"
+      className={controlledClassName}
       disabled={disabled}
       hasError={hasError}
       isLegendHidden={isLabelHidden}
       isLight={isLight}
       legend={label}
+      style={style}
     >
       <Box key={key} $hasError={hasError} $isInline={isInline}>
         {options.map(option => (

--- a/src/fields/MultiSelect.tsx
+++ b/src/fields/MultiSelect.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames'
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react'
 import { TagPicker, type TagPickerProps } from 'rsuite'
 import styled from 'styled-components'
@@ -40,6 +41,7 @@ export type MultiSelectProps<OptionValue extends OptionValueType = string> = Omi
 }
 export function MultiSelect<OptionValue extends OptionValueType = string>({
   baseContainer,
+  className,
   customSearch,
   customSearchMinQueryLength = 1,
   disabled = false,
@@ -53,6 +55,7 @@ export function MultiSelect<OptionValue extends OptionValueType = string>({
   options,
   optionValueKey,
   searchable = false,
+  style,
   value,
   ...originalProps
 }: MultiSelectProps<OptionValue>) {
@@ -61,6 +64,7 @@ export function MultiSelect<OptionValue extends OptionValueType = string>({
   /** Instance of `CustomSearch` */
   const customSearchRef = useRef(customSearch)
 
+  const controlledClassName = useMemo(() => classnames('Field-MultiSelect', className), [className])
   const controlledError = useMemo(() => normalizeString(error), [error])
   const rsuiteData = useMemo(() => getRsuiteDataFromOptions(options, optionValueKey), [options, optionValueKey])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
@@ -156,7 +160,7 @@ export function MultiSelect<OptionValue extends OptionValueType = string>({
   }, [forceUpdate])
 
   return (
-    <Field className="Field-MultiSelect">
+    <Field className={controlledClassName} style={style}>
       <Label disabled={disabled} hasError={hasError} htmlFor={originalProps.name} isHidden={isLabelHidden}>
         {label}
       </Label>

--- a/src/fields/MultiZoneEditor/index.tsx
+++ b/src/fields/MultiZoneEditor/index.tsx
@@ -1,7 +1,8 @@
 // TODO Clean, split and finalize this component.
 
+import classnames from 'classnames'
 import { equals, remove } from 'ramda'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react'
 import styled from 'styled-components'
 
 import { Accent } from '../../constants'
@@ -17,6 +18,7 @@ import type { Promisable } from 'type-fest'
 
 export type MultiZoneEditorProps = {
   addButtonLabel: string
+  className?: string | undefined
   defaultValue?: Record<string, any>[] | undefined
   disabled?: boolean | undefined
   error?: string | undefined
@@ -31,9 +33,11 @@ export type MultiZoneEditorProps = {
   onChange?: ((nextZones: Record<string, any>[] | undefined) => Promisable<void>) | undefined
   onDelete?: ((nextZones: Record<string, any>[]) => Promisable<void>) | undefined
   onEdit?: ((zone: Record<string, any>, index: number) => Promisable<void>) | undefined
+  style?: CSSProperties | undefined
 }
 export function MultiZoneEditor({
   addButtonLabel,
+  className,
   defaultValue = [],
   disabled = false,
   error,
@@ -47,12 +51,14 @@ export function MultiZoneEditor({
   onCenter,
   onChange,
   onDelete,
-  onEdit
+  onEdit,
+  style
 }: MultiZoneEditorProps) {
   const prevDefaultValueRef = useRef(defaultValue)
 
   const [zones, setZones] = useState(defaultValue)
 
+  const controlledClassName = useMemo(() => classnames('Field-MultiZoneEditor', className), [className])
   const controlledError = useMemo(() => normalizeString(error), [error])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
 
@@ -112,7 +118,13 @@ export function MultiZoneEditor({
   useFieldUndefineEffect(disabled, onChange, handleDisable)
 
   return (
-    <Fieldset className="Field-MultiZoneEditor" disabled={disabled} isLegendHidden={isLabelHidden} legend={label}>
+    <Fieldset
+      className={controlledClassName}
+      disabled={disabled}
+      isLegendHidden={isLabelHidden}
+      legend={label}
+      style={style}
+    >
       <Button
         accent={Accent.SECONDARY}
         disabled={disabled || isAddButtonDisabled}

--- a/src/fields/Search.tsx
+++ b/src/fields/Search.tsx
@@ -63,6 +63,7 @@ export function Search<OptionValue extends OptionValueType = string>({
   onQuery,
   options = [],
   optionValueKey,
+  style,
   value,
   ...originalProps
 }: SearchProps<OptionValue>) {
@@ -153,7 +154,7 @@ export function Search<OptionValue extends OptionValueType = string>({
   }, [forceUpdate])
 
   return (
-    <Field className={controlledClassName}>
+    <Field className={controlledClassName} style={style}>
       <Label
         disabled={originalProps.disabled}
         hasError={hasError}

--- a/src/fields/Select.tsx
+++ b/src/fields/Select.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames'
 import { useCallback, useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from 'react'
 import { SelectPicker, type SelectPickerProps } from 'rsuite'
 import styled from 'styled-components'
@@ -51,6 +52,7 @@ export type SelectProps<OptionValue extends OptionValueType = string> = Omit<
 }
 export function Select<OptionValue extends OptionValueType = string>({
   baseContainer,
+  className,
   customSearch,
   customSearchMinQueryLength = 1,
   disabled = false,
@@ -65,6 +67,7 @@ export function Select<OptionValue extends OptionValueType = string>({
   options,
   optionValueKey,
   searchable = false,
+  style,
   value,
   ...originalProps
 }: SelectProps<OptionValue>) {
@@ -75,6 +78,7 @@ export function Select<OptionValue extends OptionValueType = string>({
 
   const { forceUpdate } = useForceUpdate()
 
+  const controlledClassname = useMemo(() => classnames('Field-Select', className), [className])
   const controlledError = useMemo(() => normalizeString(error), [error])
   const rsuiteData = useMemo(() => getRsuiteDataFromOptions(options, optionValueKey), [options, optionValueKey])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
@@ -161,7 +165,7 @@ export function Select<OptionValue extends OptionValueType = string>({
   }, [forceUpdate])
 
   return (
-    <Field className="Field-Select">
+    <Field className={controlledClassname} style={style}>
       <Label disabled={disabled} hasError={hasError} htmlFor={originalProps.name} isHidden={isLabelHidden}>
         {label}
       </Label>

--- a/src/fields/Textarea.tsx
+++ b/src/fields/Textarea.tsx
@@ -1,3 +1,4 @@
+import classnames from 'classnames'
 import { useCallback, useMemo, useRef } from 'react'
 import { Input } from 'rsuite'
 import styled from 'styled-components'
@@ -27,6 +28,7 @@ export type TextareaProps = Omit<
   value?: string | undefined
 }
 export function Textarea({
+  className,
   error,
   isErrorMessageHidden = false,
   isLabelHidden = false,
@@ -35,11 +37,13 @@ export function Textarea({
   label,
   onChange,
   rows = 3,
+  style,
   value,
   ...originalProps
 }: TextareaProps) {
   const inputRef = useRef() as MutableRefObject<HTMLTextAreaElement>
 
+  const controlledClassname = useMemo(() => classnames('Field-Textarea', className), [className])
   const controlledError = useMemo(() => normalizeString(error), [error])
   const hasError = useMemo(() => Boolean(controlledError), [controlledError])
   const key = useKey([originalProps.disabled, originalProps.name])
@@ -58,7 +62,7 @@ export function Textarea({
   useFieldUndefineEffect(isUndefinedWhenDisabled && originalProps.disabled, onChange)
 
   return (
-    <Field className="Field-Textarea">
+    <Field className={controlledClassname} style={style}>
       <Label
         disabled={originalProps.disabled}
         hasError={hasError}

--- a/src/formiks/FormikEffect.tsx
+++ b/src/formiks/FormikEffect.tsx
@@ -8,7 +8,7 @@ import type { Promisable } from 'type-fest'
 
 export type FormikEffectProps = {
   onChange: (nextValues: Record<string, any>) => Promisable<void>
-  onError?: ((nextValues: Record<string, any>) => Promisable<void>) | undefined
+  onError?: ((nextErrors: Record<string, any>) => Promisable<void>) | undefined
 }
 export function FormikEffect({ onChange, onError }: FormikEffectProps) {
   const { errors, values } = useFormikContext<Record<string, any>>()


### PR DESCRIPTION
BREAKING CHANGE: Fields `style` & `className` props are now passed to the container.

## Related Pull Requests & Issues

None

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-mbtlfvwmgx.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
