### PR TITLE
fix(libs): ignoreLocation by default when using fuzzySearch

### DIFF
--- a/.storybook/data/species.json
+++ b/.storybook/data/species.json
@@ -1,7 +1,7 @@
 [
   {
     "code": "RIX",
-    "name": "Rangia spp"
+    "name": "Rangia spp very long name with a special string you want to look for at the end of the string to see if it is cutted or not in the index balbuzard guédalup"
   },
   {
     "code": "MTF",

--- a/src/libs/CustomSearch.ts
+++ b/src/libs/CustomSearch.ts
@@ -24,9 +24,19 @@ export type CustomSearchOptions = Partial<{
    */
   isStrict: boolean
   /**
+   * By default, location is set to 0 and distance to 100
+   * When isStrict is false, for something to be considered a match, it would have to be within
+   * (threshold) 0.4 x (distance) 100 = 40 characters away from the expected location 0. (i.e. the first 40 characters)
+   * When true, search will ignore location and distance, so it won't matter where in the string the pattern appears.
+   *
+   * @default true
+   * @see https://www.fusejs.io/concepts/scoring-theory.html#scoring-theory
+   */
+  shouldIgnoreLocation: boolean
+  /**
    * At what point does the match algorithm give up.
    *
-   * @default 0.6
+   * @default 0.4
    * @description
    * A threshold of `0.0` requires a perfect match (of both letters and location),
    * a threshold of `1.0` would match anything.
@@ -69,7 +79,8 @@ export class CustomSearch<T extends Record<string, any> = Record<string, any>> {
       isCaseSensitive = false,
       isDiacriticSensitive = false,
       isStrict = false,
-      threshold = 0.6
+      shouldIgnoreLocation = true,
+      threshold = 0.4
     }: CustomSearchOptions = {}
   ) {
     const maybeCache = cacheKey ? FUSE_SEARCH_CACHE[cacheKey] : undefined
@@ -83,7 +94,7 @@ export class CustomSearch<T extends Record<string, any> = Record<string, any>> {
     this.#fuse = new Fuse(
       normalizedCollection,
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      { isCaseSensitive, keys, threshold, useExtendedSearch: isStrict },
+      { ignoreLocation: shouldIgnoreLocation, isCaseSensitive, keys, threshold, useExtendedSearch: isStrict },
       maybeCache ? Fuse.parseIndex<T>(maybeCache.fuseSearchIndex) : undefined
     )
     this.#isDiacriticSensitive = isDiacriticSensitive

--- a/stories/fields/Search/WithCustomSearch.stories.tsx
+++ b/stories/fields/Search/WithCustomSearch.stories.tsx
@@ -56,7 +56,7 @@ export function WithCustomSearch(props: SearchProps) {
           weight: 0.1
         }
       ],
-      { isStrict: true }
+      { isStrict: false, shouldIgnoreLocation: true }
     )
   )
 


### PR DESCRIPTION
without this option, fuse searches in the first (threshold x 100) characters only.


## Related Pull Requests & Issues
- https://github.com/MTES-MCT/monitorenv/issues/443

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-htxdphmqcc.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
