### PR TITLE
feat(fields): add isReadOnly prop on multiRadio component and add custom style for plaintext

### DIFF
--- a/src/assets/stylesheets/rsuite-override.css
+++ b/src/assets/stylesheets/rsuite-override.css
@@ -350,6 +350,10 @@ label:hover .rs-checkbox-wrapper .rs-checkbox-inner:before {
   line-height: 17px;
 }
 
+.rs-radio:hover .rs-radio-inner:before {
+  border-color: var(--charcoal);
+}
+
 /* form */
 .rs-form:not(.rs-form-inline) .rs-form-group:not(:last-child) {
   margin-bottom: 32px;
@@ -699,4 +703,8 @@ label:hover .rs-checkbox-wrapper .rs-checkbox-inner:before {
 .rs-table-row-expanded {
   height: 100px !important;
   background: white !important;
+}
+
+.rs-plaintext {
+  font-size: 13px !important;
 }

--- a/src/fields/MultiRadio.tsx
+++ b/src/fields/MultiRadio.tsx
@@ -65,7 +65,7 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
     [onChange]
   )
 
-  useFieldUndefineEffect(isUndefinedWhenDisabled && disabled, onChange)
+  useFieldUndefineEffect(isUndefinedWhenDisabled && disabled && !isReadOnly, onChange)
 
   return (
     <Fieldset

--- a/src/fields/MultiRadio.tsx
+++ b/src/fields/MultiRadio.tsx
@@ -21,6 +21,7 @@ export type MultiRadioProps<OptionValue extends OptionValueType = string> = {
   isInline?: boolean | undefined
   isLabelHidden?: boolean | undefined
   isLight?: boolean | undefined
+  isReadOnly?: boolean
   isUndefinedWhenDisabled?: boolean | undefined
   label: string
   name: string
@@ -37,6 +38,7 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
   isInline = false,
   isLabelHidden = false,
   isLight = false,
+  isReadOnly = false,
   isUndefinedWhenDisabled = false,
   label,
   name,
@@ -75,7 +77,7 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
       legend={label}
       style={style}
     >
-      <Box key={key} $hasError={hasError} $isInline={isInline}>
+      <Box key={key} $hasError={hasError} $isInline={isInline} $isReadOnly={isReadOnly}>
         {options.map(option => (
           <Radio
             key={JSON.stringify(option.value)}
@@ -83,6 +85,7 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
             disabled={disabled}
             name={name}
             onChange={(_: any, isChecked: boolean) => handleChange(option.value, isChecked)}
+            readOnly={isReadOnly}
           >
             {option.label}
           </Radio>
@@ -97,6 +100,7 @@ export function MultiRadio<OptionValue extends OptionValueType = string>({
 const Box = styled.div<{
   $hasError: boolean
   $isInline: boolean
+  $isReadOnly: boolean
 }>`
   color: ${p => p.theme.color.gunMetal};
   display: flex;
@@ -134,6 +138,34 @@ const Box = styled.div<{
     css`
       > .rs-radio:not(:first-child) {
         margin-left: 12px;
+      }
+    `}
+
+    ${p =>
+    p.$isReadOnly &&
+    css`
+      .rs-radio {
+        .rs-radio-checker {
+          label {
+            cursor: not-allowed;
+            .rs-radio-wrapper [type='radio'] {
+              cursor: not-allowed;
+            }
+          }
+        }
+      }
+      .rs-radio:not(.rs-radio-checked):hover .rs-radio-inner:before {
+        border-color: ${p.theme.color.lightGray};
+      }
+      .rs-radio:not(.rs-radio-checked) .rs-radio-inner:before {
+        background-color: ${p.theme.color.white};
+      }
+      .rs-radio:not(.rs-radio-checked) {
+        .rs-radio-checker {
+          label {
+            color: ${p.theme.color.slateGray};
+          }
+        }
       }
     `}
 `

--- a/stories/fields/MultiRadio.stories.tsx
+++ b/stories/fields/MultiRadio.stories.tsx
@@ -5,6 +5,7 @@ import { generateStoryDecorator } from '../../.storybook/components/StoryDecorat
 import { MultiRadio, useFieldControl } from '../../src'
 
 import type { MultiRadioProps } from '../../src'
+import type { Meta } from '@storybook/react'
 
 const args: MultiRadioProps = {
   disabled: false,
@@ -24,7 +25,7 @@ const args: MultiRadioProps = {
   value: undefined
 }
 
-export default {
+const meta: Meta<MultiRadioProps> = {
   title: 'Fields/MultiRadio',
   component: MultiRadio,
 
@@ -43,6 +44,7 @@ export default {
     })
   ]
 }
+export default meta
 
 export function _MultiRadio(props: MultiRadioProps) {
   const [outputValue, setOutputValue] = useState<string | undefined | '∅'>('∅')

--- a/stories/fields/MultiRadio.stories.tsx
+++ b/stories/fields/MultiRadio.stories.tsx
@@ -51,9 +51,18 @@ export function _MultiRadio(props: MultiRadioProps) {
 
   return (
     <>
-      <MultiRadio {...props} onChange={controlledOnChange} value={controlledValue} />
+      <div style={{ marginBottom: '32px' }}>
+        <MultiRadio {...props} onChange={controlledOnChange} value={controlledValue} />
 
-      {outputValue !== '∅' && <Output value={outputValue} />}
+        {outputValue !== '∅' && <Output value={outputValue} />}
+      </div>
+      <MultiRadio
+        {...props}
+        isReadOnly
+        label="Multiradio in readOnly mode"
+        onChange={controlledOnChange}
+        value="FIRST_OPTION"
+      />
     </>
   )
 }

--- a/stories/fields/TextInput.stories.tsx
+++ b/stories/fields/TextInput.stories.tsx
@@ -61,6 +61,17 @@ export function _TextInput(props: TextInputProps) {
           placeholder="A text input placeholder"
           size={Size.LARGE}
         />
+
+        <div style={{ marginTop: '32px' }}>
+          <TextInput
+            label="A text input with plaintext prop"
+            name="myTextInputWithPlaintextProp"
+            placeholder="A text input placeholder"
+            plaintext
+            size={Size.LARGE}
+            value="Plain text value"
+          />
+        </div>
       </Showcase>
     </>
   )


### PR DESCRIPTION
Customize multiRadio style for readOnly mode

![Capture d’écran 2023-09-19 à 09 11 49](https://github.com/MTES-MCT/monitor-ui/assets/23258718/95988924-6308-4c0a-b34c-31e2d92c48a0)

## Related Pull Requests & Issues

- MTES-MCT/monitorenv#827


## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-rsimvjgski.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
