### PR TITLE
fix(Multiradio): rework sizing and centering

### DIFF
--- a/src/assets/stylesheets/rsuite-override.css
+++ b/src/assets/stylesheets/rsuite-override.css
@@ -312,13 +312,13 @@ label:hover .rs-checkbox-wrapper .rs-checkbox-inner:before {
 .rs-radio-wrapper::before,
 .rs-radio-wrapper .rs-radio-inner::before,
 .rs-radio-wrapper {
-  width: 13px;
-  height: 13px;
+  width: 14px;
+  height: 14px;
 }
 
 .rs-radio-wrapper .rs-radio-inner::before {
   background: var(--gainsboro);
-  border-width: 2.5px;
+  border-width: 2px;
 }
 
 .rs-radio-checked .rs-radio-wrapper .rs-radio-inner::before {
@@ -329,10 +329,10 @@ label:hover .rs-checkbox-wrapper .rs-checkbox-inner:before {
 /* center of radio button when checked */
 .rs-radio-wrapper .rs-radio-inner::after {
   background: var(--charcoal);
-  width: 8px;
-  height: 8px;
-  margin-top: 5px;
-  margin-left: 5px;
+  width: 6px;
+  height: 6px;
+  margin-top: 4px;
+  margin-left: 4px;
 }
 
 .rs-radio.rs-radio-disabled .rs-radio-wrapper .rs-radio-inner::after {


### PR DESCRIPTION
## Description

J'avais un probleme au niveau du display des Radio buttons qui s'affichent très mal dans RNav. Ca s'affiche mieux dans Monitor (je sais pas pourquoi) mais si vous regardez bien précisément, il y a un décalage de 1px aussi chez Monitor.
J'ai retravaillé les tailles et l'alignement (c'est dur de center align dans un object qui a une taille impaire)

avant:
<img width="330" alt="Screenshot 2023-12-17 at 18 03 27" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/13bd55d7-639b-437b-992d-935589ab8430">

après:
<img width="384" alt="Screenshot 2023-12-17 at 18 03 59" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/dbf197b7-64d2-4e6c-b187-f11d926aa096">


## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-ltoxkuhhpe.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
