### PR TITLE
fix(CoordinatesInput): fix light mode

### DIFF
--- a/src/fields/CoordinatesInput/DDCoordinatesInput.tsx
+++ b/src/fields/CoordinatesInput/DDCoordinatesInput.tsx
@@ -2,6 +2,7 @@ import { useMemo, useRef, useState } from 'react'
 import styled from 'styled-components'
 import { useDebouncedCallback } from 'use-debounce'
 
+import { THEME } from '../../theme'
 import { isNumeric } from '../../utils/isNumeric'
 
 import type { Coordinates } from '../../types'
@@ -9,10 +10,16 @@ import type { Coordinates } from '../../types'
 type DDCoordinatesInputProps = {
   coordinates: Coordinates | undefined
   disabled: boolean | undefined
+  isLight: boolean | undefined
   onChange: (nextCoordinates: Coordinates, coordinates: Coordinates | undefined) => void
 }
 // TODO This field should return undefined when cleared (i.e.: Select all & Backspace/Delete)
-export function DDCoordinatesInput({ coordinates, disabled = false, onChange }: DDCoordinatesInputProps) {
+export function DDCoordinatesInput({
+  coordinates,
+  disabled = false,
+  isLight = false,
+  onChange
+}: DDCoordinatesInputProps) {
   const latitudeInputRef = useRef<HTMLInputElement>()
   const longitudeInputRef = useRef<HTMLInputElement>()
 
@@ -77,7 +84,10 @@ export function DDCoordinatesInput({ coordinates, disabled = false, onChange }: 
         disabled={disabled}
         onChange={() => handleChange(coordinates)}
         placeholder="Latitude"
-        style={{ border: latitudeError ? '1px solid red' : undefined }}
+        style={{
+          backgroundColor: isLight ? THEME.color.white : THEME.color.gainsboro,
+          border: latitudeError ? '1px solid red' : undefined
+        }}
       />
       <DDInput
         ref={longitudeInputRef as any}
@@ -86,7 +96,10 @@ export function DDCoordinatesInput({ coordinates, disabled = false, onChange }: 
         disabled={disabled}
         onChange={() => handleChange(coordinates)}
         placeholder="Longitude"
-        style={{ border: longitudeError ? '1px solid red' : undefined }}
+        style={{
+          backgroundColor: isLight ? THEME.color.white : THEME.color.gainsboro,
+          border: longitudeError ? '1px solid red' : undefined
+        }}
       />
       <CoordinatesType>(DD)</CoordinatesType>
       <Error>{latitudeError}</Error>

--- a/src/fields/CoordinatesInput/DMDCoordinatesInput.tsx
+++ b/src/fields/CoordinatesInput/DMDCoordinatesInput.tsx
@@ -4,6 +4,7 @@ import { IMaskInput } from 'react-imask'
 import styled from 'styled-components'
 
 import { CoordinatesFormat, WSG84_PROJECTION } from '../../constants'
+import { THEME } from '../../theme'
 import { getCoordinates } from '../../utils/coordinates'
 import { isNumeric } from '../../utils/isNumeric'
 
@@ -17,6 +18,7 @@ type DMDCoordinatesInputProps = {
   coordinates: Coordinates | undefined
   coordinatesFormat: CoordinatesFormat
   disabled: boolean | undefined
+  isLight: boolean | undefined
   onChange: (nextCoordinates: Coordinates, coordinates: Coordinates | undefined) => void
 }
 // TODO This field should return undefined when cleared (i.e.: Select all & Backspace/Delete)
@@ -24,6 +26,7 @@ export function DMDCoordinatesInput({
   coordinates,
   coordinatesFormat,
   disabled = false,
+  isLight,
   onChange
 }: DMDCoordinatesInputProps) {
   const [error, setError] = useState('')
@@ -104,7 +107,10 @@ export function DMDCoordinatesInput({
         onComplete={(_, mask) => completeCoordinates(mask)}
         placeholder="__° __.___′ _ ___° __.___′"
         radix="."
-        style={{ border: error ? '1px solid red' : undefined }}
+        style={{
+          backgroundColor: isLight ? THEME.color.white : THEME.color.gainsboro,
+          border: error ? '1px solid red' : undefined
+        }}
         // TODO Use `defaultValue` here.
         value={value}
       />

--- a/src/fields/CoordinatesInput/DMSCoordinatesInput.tsx
+++ b/src/fields/CoordinatesInput/DMSCoordinatesInput.tsx
@@ -3,6 +3,8 @@ import { useCallback, useMemo } from 'react'
 import CoordinateInput from 'react-coordinate-input'
 import styled from 'styled-components'
 
+import { THEME } from '../../theme'
+
 import type { CoordinatesFormat } from '../../constants'
 import type { Coordinates } from '../../types'
 
@@ -10,12 +12,14 @@ type DMSCoordinatesInputProps = {
   coordinates: Coordinates | undefined
   coordinatesFormat: CoordinatesFormat
   disabled: boolean | undefined
+  isLight: boolean | undefined
   onChange: (nextCoordinates: Coordinates | undefined, coordinates: Coordinates | undefined) => void
 }
 export function DMSCoordinatesInput({
   coordinates,
   coordinatesFormat,
   disabled = false,
+  isLight,
   onChange
 }: DMSCoordinatesInputProps) {
   /** Convert the coordinates to the [latitude, longitude] string format */
@@ -43,6 +47,9 @@ export function DMSCoordinatesInput({
         ddPrecision={6}
         disabled={disabled}
         onChange={(_, { dd }) => update(dd)}
+        style={{
+          backgroundColor: isLight ? THEME.color.white : THEME.color.gainsboro
+        }}
         // TODO Use `defaultValue` here.
         value={defaultValue}
       />

--- a/src/fields/CoordinatesInput/index.tsx
+++ b/src/fields/CoordinatesInput/index.tsx
@@ -51,6 +51,7 @@ export function CoordinatesInput({
             coordinates={defaultValue}
             coordinatesFormat={CoordinatesFormat.DEGREES_MINUTES_SECONDS}
             disabled={nativeProps.disabled}
+            isLight={isLight}
             onChange={onChange}
           />
         )
@@ -61,6 +62,7 @@ export function CoordinatesInput({
             coordinates={defaultValue}
             coordinatesFormat={CoordinatesFormat.DEGREES_MINUTES_DECIMALS}
             disabled={nativeProps.disabled}
+            isLight={isLight}
             onChange={onChange}
           />
         )
@@ -70,6 +72,7 @@ export function CoordinatesInput({
           <DDCoordinatesInput
             coordinates={defaultValue as [number, number]}
             disabled={nativeProps.disabled}
+            isLight={isLight}
             onChange={onChange}
           />
         )
@@ -77,19 +80,13 @@ export function CoordinatesInput({
       default:
         return undefined
     }
-  }, [defaultValue, nativeProps.disabled, onChange, coordinatesFormat])
+  }, [defaultValue, nativeProps.disabled, onChange, coordinatesFormat, isLight])
 
   // TODO We must add a `handleDisable()` callback here to effectively empty the inputs when disabling this field.
   useFieldUndefineEffect(nativeProps.disabled, onChange /* , handleDisable */)
 
   return (
-    <StyledFieldset
-      className={controlledClassName}
-      isLegendHidden={isLabelHidden}
-      isLight={isLight}
-      legend={label}
-      {...nativeProps}
-    >
+    <StyledFieldset className={controlledClassName} isLegendHidden={isLabelHidden} legend={label} {...nativeProps}>
       {getCoordinatesInput()}
 
       {hasError && <FieldError>{controlledError}</FieldError>}


### PR DESCRIPTION
## Description

Le Coordinate Input était assez cassé en light mode, il héritait d'un Fieldset en mode light qui ajoute un padding non nécessaire.
Ce padding est très utile pour les MultiRadio et MultiCheckbox mais pas pour les autres composants.
Je me suis inspiré d'autres composants (DatePicker par ex) qui déplace la prop `isLight` du Fieldset vers l'Input.

avant :
<img width="633" alt="Screenshot 2023-12-17 at 19 34 09" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/56248c3f-0c3d-4b5e-b5f6-a5c2d5611d37">
<img width="645" alt="Screenshot 2023-12-17 at 19 28 29" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/85a187a3-19ea-4bc3-9192-2dd8921e65e3">

apres :
<img width="621" alt="Screenshot 2023-12-17 at 19 28 23" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/c9521bd9-100f-4154-9a7d-44a7cff21ab0">
<img width="655" alt="Screenshot 2023-12-17 at 19 28 37" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/bd55729c-9601-4750-b48c-fb82e595b3d0">



## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-hwiannwjnf.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
