### PR TITLE
fix(MultiSelect): fix for long labels in virtualized mode

### DIFF
--- a/src/fields/MultiSelect.tsx
+++ b/src/fields/MultiSelect.tsx
@@ -304,7 +304,7 @@ const Box = styled.div<{
     > .rs-picker-check-menu {
       margin: 0;
 
-      > div[role='option'] {
+      div[role='option'] {
         > .rs-check-item {
           > .rs-checkbox-checker {
             > label {


### PR DESCRIPTION
## Description

Petit souci au niveau du MultiSelect lorsque les labels sont vraiment longs (typiquement pour les Natinfs).
Le problème n'apparait qu'en mode virtualized (j'ai 1000 items dans la liste). C'est correctement truncate en mode normal ceci dit.

avant :
<img width="761" alt="Screenshot 2023-12-19 at 16 56 50" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/bd518048-ec53-4464-b307-5acc549ffd75">

après :
<img width="769" alt="Screenshot 2023-12-19 at 16 57 47" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/bb133254-41b8-4e08-aaa8-9f4dcc79afa7">

On remarquera que le text n'est pas truncate mais plutôt que le Select devient scrollable horizontalement. C'est un peu que l'on peut rediscuter.


## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-cxuafdiufy.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
