### PR TITLE
style(Checkbox) - override default readOnly mode

### DIFF
--- a/src/fields/Checkbox.tsx
+++ b/src/fields/Checkbox.tsx
@@ -81,4 +81,28 @@ const StyledCheckbox = styled(RsuiteCheckbox as any)`
       top: 2px !important;
     }
   }
+
+  // in readOnly, override hover effects and change cursor
+  ${props =>
+    props.readOnly &&
+    `
+      > .rs-checkbox-checker:hover {
+        label {
+          cursor: not-allowed;
+        }
+        .rs-checkbox-wrapper .rs-checkbox-inner::before {
+          border-color: ${props.theme.color.lightGray};
+          background-color: ${props.theme.color.gainsboro};
+        }
+      }
+
+      &.rs-checkbox-checked {
+        > .rs-checkbox-checker:hover {
+          .rs-checkbox-wrapper .rs-checkbox-inner::before {
+            border-color: ${props.theme.color.charcoal};
+            background-color: ${props.theme.color.charcoal};
+          }
+        }
+      }
+    `}
 `

--- a/stories/fields/Checkbox.stories.tsx
+++ b/stories/fields/Checkbox.stories.tsx
@@ -11,7 +11,8 @@ const args: CheckboxProps = {
   disabled: false,
   error: '',
   label: 'Check me',
-  name: 'myCheckbox'
+  name: 'myCheckbox',
+  readOnly: false
 }
 
 export default {


### PR DESCRIPTION
## Description

Lors des tests RapportNav, Clémence s'est aperçu que le mode readOnly sur les Checkbox ne respectait pas les designs. Elle le voulait plus passif, sans hover, comme les Input ou Radio.

avant:

https://github.com/MTES-MCT/monitor-ui/assets/4593884/caf858d4-76a1-4bb4-b84f-8f1232f852d1


après:


https://github.com/MTES-MCT/monitor-ui/assets/4593884/2d7021ff-52d9-49be-beb7-7d0d1290f8e7



## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-mvsqhvores.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
