### PR TITLE
fix(cypress): widen input type for fill() on TextInput

### DIFF
--- a/src/cypress/commands/fill/fillTextInput.ts
+++ b/src/cypress/commands/fill/fillTextInput.ts
@@ -9,12 +9,12 @@ export function fillTextInput(fieldElement: HTMLDivElement, value: string | unde
 
   cy.wrap(fieldElement).scrollIntoView({ offset: { left: 0, top: -100 } })
 
-  cy.wrap(fieldElement).find('input[type="text"]').forceClear().wait(250)
+  cy.wrap(fieldElement).find('input').forceClear().wait(250)
 
   // If `value` is undefined, we don't need to input anything
   if (!value) {
     return
   }
 
-  cy.wrap(fieldElement).find('input[type="text"]').forceType(value).wait(250)
+  cy.wrap(fieldElement).find('input').forceType(value).wait(250)
 }


### PR DESCRIPTION
## Related Pull Requests & Issues

- MTES-MCT/monitorfish#2979

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-badvvyyent.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
