### PR TITLE
ci(github)!: fix typo in E2E Test job

### DIFF
--- a/src/fields/MultiCascader/index.tsx
+++ b/src/fields/MultiCascader/index.tsx
@@ -25,8 +25,6 @@ export type MultiCascaderProps<OptionValue extends OptionValueType = string> = O
   RsuiteMultiCascaderProps,
   'as' | 'container' | 'data' | 'defaultValue' | 'id' | 'onChange' | 'renderMenuItem' | 'value'
 > & {
-  /** Used to pass something else than `window.document` as a base container to attach global events listeners. */
-  baseContainer?: Document | HTMLDivElement | null | undefined
   error?: string | undefined
   isErrorMessageHidden?: boolean | undefined
   isLabelHidden?: boolean | undefined

--- a/src/fields/MultiSelect.tsx
+++ b/src/fields/MultiSelect.tsx
@@ -23,7 +23,6 @@ export type MultiSelectProps<OptionValue extends OptionValueType = string> = Omi
   TagPickerProps,
   'as' | 'container' | 'data' | 'defaultValue' | 'id' | 'onChange' | 'renderMenuItem' | 'value' | 'valueKey'
 > & {
-  /** Used to pass something else than `window.document` as a base container to attach global events listeners. */
   customSearch?: CustomSearch<Option<OptionValue>>
   /** Minimum search query length required to trigger custom search filtering. */
   customSearchMinQueryLength?: number | undefined

--- a/src/fields/Search.tsx
+++ b/src/fields/Search.tsx
@@ -29,8 +29,6 @@ export type SearchProps<OptionValue extends OptionValueType = string> = Omit<
   'as' | 'container' | 'data' | 'defaultValue' | 'id' | 'onChange' | 'open' | 'onSelect' | 'size' | 'value' | 'valueKey'
 > & {
   MenuItem?: ElementType | undefined
-  /** Used to pass something else than `window.document` as a base container to attach global events listeners. */
-  baseContainer?: Document | HTMLDivElement | null | undefined
   customSearch?: CustomSearch<Option<OptionValue>> | undefined
   /** Minimum search query length required to trigger custom search filtering. */
   customSearchMinQueryLength?: number | undefined

--- a/stories/fields/DateRangePicker.stories.tsx
+++ b/stories/fields/DateRangePicker.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<DateRangePickerWithDateDateProps> = {
   component: DateRangePicker,
 
   argTypes: {
+    baseContainer: ARG_TYPE.OPTIONAL_BASE_CONTAINER,
     defaultValue: {
       ...ARG_TYPE.NO_CONTROL_INPUT,
       table: {

--- a/stories/fields/MultiCascader.stories.tsx
+++ b/stories/fields/MultiCascader.stories.tsx
@@ -21,7 +21,6 @@ const meta: Meta<MultiCascaderProps<string>> = {
   component: MultiCascader,
 
   argTypes: {
-    baseContainer: ARG_TYPE.OPTIONAL_BASE_CONTAINER,
     error: ARG_TYPE.OPTIONAL_STRING,
     isErrorMessageHidden: ARG_TYPE.OPTIONAL_BOOLEAN,
     isLabelHidden: ARG_TYPE.OPTIONAL_BOOLEAN,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,7 @@
   "include": ["**/*.js", "**/*.jsx", "**/*.ts", "**/*.tsx", ".storybook/**/*", "vite.config.ts"],
   "exclude": [
     "config/*",
+    "coverage/*",
     "dist/*",
     "e2e/release/sample/*",
     "node_modules/*",


### PR DESCRIPTION
BREAKING CHANGE:

- `baseContainer` prop has been removed in `MultiCascader`.
- `baseContainer` prop has been removed in `MultiSelect`.
- `baseContainer` prop has been removed in `Search`.

## Related Pull Requests & Issues

- MTES-MCT/monitorfish#2979

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-moabrfmquj.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
