### PR TITLE
fix(fields): prevent resizing from exceeding 100% parent width

### DIFF
--- a/src/fields/Textarea.tsx
+++ b/src/fields/Textarea.tsx
@@ -114,6 +114,7 @@ const StyledRsuiteInput = styled(RsuiteInput)<CommonFieldStyleProps>`
   font-weight: 500;
   padding: 7px 8px;
   width: 100%;
+  max-width: 100%;
 
   &::placeholder {
     color: ${getFieldPlaceholderColorFactoryForState('default')};


### PR DESCRIPTION
Un truc qu'on a remarqué avec Clémence : le textarea peut dépasser son parent lors du resize et on aimerait bloquer ce comportement.

https://github.com/MTES-MCT/monitor-ui/assets/4593884/c4b788db-149e-4acf-adde-6445990e9bc1



## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-pnymxcivak.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
