### PR TITLE
fix(fields): CoordinatesInput now displays the * when isRequired

### DIFF
--- a/src/fields/CoordinatesInput/index.tsx
+++ b/src/fields/CoordinatesInput/index.tsx
@@ -162,12 +162,13 @@ const StyledFieldset = styled(Fieldset)<CommonFieldStyleProps>`
     &:focus-visible {
       outline: 0;
     }
-    ${p =>
-      p.$isRequired &&
-      `
-        :after {
+  }
+
+  ${p =>
+    p.$isRequired &&
+    `
+        legend:after {
             content:" *";
             color: ${p.theme.color.maximumRed};
           }`}
-  }
 `


### PR DESCRIPTION
## Description

L'astérisque rouge ne se montrait pas alors qu'il y avaut la prop isRequired


## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-qdeqztjvss.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
