### PR TITLE
feat(icons): introduce title props on icons for additional info on hover

### DIFF
--- a/scripts/icons/generateIcons.js
+++ b/scripts/icons/generateIcons.js
@@ -14,6 +14,7 @@ async function generateIcon({ count, index, svgIconPath, template }) {
     .replace(/ data-name="[^"]*"/g, '')
     .replace(/ id="[^"]*"/g, '')
   const svgIconSourceWithProps = svgIconSourceWithoutExtraneousProps.replace(/>/, ` {...nativeProps}>`)
+
   const tsxIconSource = template
     .replace(/\/\*ICON_NAME\*\//g, iconName)
     .replace(/\/\*ICON_SVG_SOURCE\*\//g, svgIconSourceWithProps)

--- a/scripts/icons/iconTemplate.tsxt
+++ b/scripts/icons/iconTemplate.tsxt
@@ -2,8 +2,8 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export const /*ICON_NAME*/ = ({ color, size, ...nativeProps}: IconProps) => (
-  <IconBox $size={size} $color={color}>
+export const /*ICON_NAME*/ = ({ color, size, title, ...nativeProps}: IconProps) => (
+  <IconBox $size={size} $color={color} title={title}>
     /*ICON_SVG_SOURCE*/
   </IconBox>
 )

--- a/src/icons/ActivityFeed.tsx
+++ b/src/icons/ActivityFeed.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function ActivityFeed({ color, size, ...nativeProps }: IconProps) {
+export function ActivityFeed({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(40 -41)">
           <g>

--- a/src/icons/Alert.tsx
+++ b/src/icons/Alert.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Alert({ color, size, ...nativeProps }: IconProps) {
+export function Alert({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <path

--- a/src/icons/Anchor.tsx
+++ b/src/icons/Anchor.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Anchor({ color, size, ...nativeProps }: IconProps) {
+export function Anchor({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <path

--- a/src/icons/Archive.tsx
+++ b/src/icons/Archive.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Archive({ color, size, ...nativeProps }: IconProps) {
+export function Archive({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M138,2H122V8h1V18h14V8h1ZM124,4h12V6H124Zm11,12H125V8h10Z"

--- a/src/icons/Attention.tsx
+++ b/src/icons/Attention.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Attention({ color, size, ...nativeProps }: IconProps) {
+export function Attention({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(200 -82)">
           <g fill="none" strokeMiterlimit="10">

--- a/src/icons/Calendar.tsx
+++ b/src/icons/Calendar.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Calendar({ color, size, ...nativeProps }: IconProps) {
+export function Calendar({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(280 -41)">
           <g>

--- a/src/icons/Car.tsx
+++ b/src/icons/Car.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Car({ color, size, ...nativeProps }: IconProps) {
+export function Car({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-200 -164)">
           <path

--- a/src/icons/Check.tsx
+++ b/src/icons/Check.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Check({ color, size, ...nativeProps }: IconProps) {
+export function Check({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(40 -82)">
           <g fill="none" strokeMiterlimit="10">

--- a/src/icons/Chevron.tsx
+++ b/src/icons/Chevron.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Chevron({ color, size, ...nativeProps }: IconProps) {
+export function Chevron({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(0 -82)">
           <g fill="none" strokeMiterlimit="10">

--- a/src/icons/Clock.tsx
+++ b/src/icons/Clock.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Clock({ color, size, ...nativeProps }: IconProps) {
+export function Clock({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(240 -41)">
           <g>

--- a/src/icons/Close.tsx
+++ b/src/icons/Close.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Close({ color, size, ...nativeProps }: IconProps) {
+export function Close({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(160 -82)">
           <g fill="none" strokeMiterlimit="10">

--- a/src/icons/Comment.tsx
+++ b/src/icons/Comment.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Comment({ color, size, ...nativeProps }: IconProps) {
+export function Comment({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <clipPath>
           <path d="m0 0h20v20h-20z" />

--- a/src/icons/Confirm.tsx
+++ b/src/icons/Confirm.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Confirm({ color, size, ...nativeProps }: IconProps) {
+export function Confirm({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-40)">
           <path d="M50,1a9,9,0,1,0,9,9A9,9,0,0,0,50,1Zm0,16a7,7,0,1,1,7-7A7,7,0,0,1,50,17Z" fill="currentColor" />

--- a/src/icons/ControlUnit.tsx
+++ b/src/icons/ControlUnit.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function ControlUnit({ color, size, ...nativeProps }: IconProps) {
+export function ControlUnit({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(80 205)">
           <g>

--- a/src/icons/ControlUnitFilled.tsx
+++ b/src/icons/ControlUnitFilled.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function ControlUnitFilled({ color, size, ...nativeProps }: IconProps) {
+export function ControlUnitFilled({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="18.25" viewBox="0 0 14 18.25" width="14" {...nativeProps}>
         <g transform="translate(77 204.25)">
           <rect fill="currentColor" height="12" transform="translate(-64 -188) rotate(90)" width="2" />

--- a/src/icons/Delete.tsx
+++ b/src/icons/Delete.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Delete({ color, size, ...nativeProps }: IconProps) {
+export function Delete({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-23.798 -14.096)">
           <g>

--- a/src/icons/Display.tsx
+++ b/src/icons/Display.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Display({ color, size, ...nativeProps }: IconProps) {
+export function Display({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(0 -40)">
           <g>

--- a/src/icons/Dot.tsx
+++ b/src/icons/Dot.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Dot({ color, size, ...nativeProps }: IconProps) {
+export function Dot({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g fill="none" transform="translate(1 1)">
           <path d="M9,2a7,7,0,1,0,7,7A7,7,0,0,0,9,2Z" stroke="none" />

--- a/src/icons/DotFilled.tsx
+++ b/src/icons/DotFilled.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function DotFilled({ color, size, ...nativeProps }: IconProps) {
+export function DotFilled({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(1 1)">
           <path d="M9,2a7,7,0,1,0,7,7A7,7,0,0,0,9,2Z" fill="currentColor" transform="translate(0 0)" />

--- a/src/icons/DoubleChevron.tsx
+++ b/src/icons/DoubleChevron.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function DoubleChevron({ color, size, ...nativeProps }: IconProps) {
+export function DoubleChevron({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g>
           <g fill="none" strokeMiterlimit="10">

--- a/src/icons/Download.tsx
+++ b/src/icons/Download.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Download({ color, size, ...nativeProps }: IconProps) {
+export function Download({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-80)">
           <g>

--- a/src/icons/Drapeau.tsx
+++ b/src/icons/Drapeau.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Drapeau({ color, size, ...nativeProps }: IconProps) {
+export function Drapeau({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="#000091" height="12" transform="translate(1 4)" width="6" />
         <rect fill="#e1000f" height="12" transform="translate(13 4)" width="6" />

--- a/src/icons/Duplicate.tsx
+++ b/src/icons/Duplicate.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Duplicate({ color, size, ...nativeProps }: IconProps) {
+export function Duplicate({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M6,2V5H3V18H14V15h3V2Zm6,14H5V7h7Zm3-3H14V5H8V4h7Z" fill="currentColor" />
         <rect fill="none" height="20" width="20" />

--- a/src/icons/Edit.tsx
+++ b/src/icons/Edit.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Edit({ color, size, ...nativeProps }: IconProps) {
+export function Edit({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-80)">
           <path

--- a/src/icons/EditUnbordered.tsx
+++ b/src/icons/EditUnbordered.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function EditUnbordered({ color, size, ...nativeProps }: IconProps) {
+export function EditUnbordered({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <g>

--- a/src/icons/Expand.tsx
+++ b/src/icons/Expand.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Expand({ color, size, ...nativeProps }: IconProps) {
+export function Expand({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20.076" viewBox="0 0 20.068 20.076" width="20.068" {...nativeProps}>
         <path
           d="M12114.779,15768.074v-1.512h5.719l-6.488-6.49,1.061-1.061,6.5,6.482v-5.713h1.5v8.293Zm-10.271-17.5v5.719H12103v-8.3h8.293v1.512h-5.719l6.488,6.49-1.068,1.066Z"

--- a/src/icons/Favorite.tsx
+++ b/src/icons/Favorite.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Favorite({ color, size, ...nativeProps }: IconProps) {
+export function Favorite({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-300 -208)">
           <path

--- a/src/icons/FilledArrow.tsx
+++ b/src/icons/FilledArrow.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function FilledArrow({ color, size, ...nativeProps }: IconProps) {
+export function FilledArrow({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(320 -41)">
           <path d="M-313,43V59l8-8Z" fill="currentColor" />

--- a/src/icons/Filter.tsx
+++ b/src/icons/Filter.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Filter({ color, size, ...nativeProps }: IconProps) {
+export function Filter({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-930 -294)">
           <path

--- a/src/icons/FilterBis.tsx
+++ b/src/icons/FilterBis.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function FilterBis({ color, size, ...nativeProps }: IconProps) {
+export function FilterBis({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g>
           <rect fill="none" height="20" width="20" />

--- a/src/icons/Fishery.tsx
+++ b/src/icons/Fishery.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Fishery({ color, size, ...nativeProps }: IconProps) {
+export function Fishery({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(80 -41)">
           <g>

--- a/src/icons/FishingEngine.tsx
+++ b/src/icons/FishingEngine.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function FishingEngine({ color, size, ...nativeProps }: IconProps) {
+export function FishingEngine({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(0 -41)">
           <path

--- a/src/icons/FleetSegment.tsx
+++ b/src/icons/FleetSegment.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function FleetSegment({ color, size, ...nativeProps }: IconProps) {
+export function FleetSegment({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <g>

--- a/src/icons/Focus.tsx
+++ b/src/icons/Focus.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Focus({ color, size, ...nativeProps }: IconProps) {
+export function Focus({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(320 -82)">
           <g>

--- a/src/icons/FocusVessel.tsx
+++ b/src/icons/FocusVessel.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function FocusVessel({ color, size, ...nativeProps }: IconProps) {
+export function FocusVessel({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M8.666,14.994a.138.138,0,0,1-.054-.034.142.142,0,0,1-.04-.081l-.4-3.05-3.05-.4a.139.139,0,0,1-.114-.094.137.137,0,0,1,.033-.144L9.3,6.934A.139.139,0,0,1,9.351,6.9l5.463-1.893a.14.14,0,0,1,.178.178L13.1,10.649a.139.139,0,0,1-.033.053L8.809,14.959a.141.141,0,0,1-.1.041A.161.161,0,0,1,8.666,14.994Z"

--- a/src/icons/FocusZones.tsx
+++ b/src/icons/FocusZones.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function FocusZones({ color, size, ...nativeProps }: IconProps) {
+export function FocusZones({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g>
           <path

--- a/src/icons/Hide.tsx
+++ b/src/icons/Hide.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Hide({ color, size, ...nativeProps }: IconProps) {
+export function Hide({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M15.635,5.779l2.143-2.143L16.364,2.222l-2.55,2.55A9.786,9.786,0,0,0,10,4a9.674,9.674,0,0,0-9,6,9.532,9.532,0,0,0,3.365,4.22L2.222,16.364l1.414,1.414,2.55-2.55A9.786,9.786,0,0,0,10,16a9.674,9.674,0,0,0,9-6A9.541,9.541,0,0,0,15.635,5.779ZM6,10a4,4,0,0,1,4-4,3.96,3.96,0,0,1,2.02.566L10.71,7.875A2.225,2.225,0,0,0,10,7.75,2.25,2.25,0,0,0,7.75,10a2.225,2.225,0,0,0,.125.71L6.566,12.02A3.96,3.96,0,0,1,6,10Zm4,4a3.96,3.96,0,0,1-2.02-.566l1.31-1.309a2.225,2.225,0,0,0,.71.125A2.25,2.25,0,0,0,12.25,10a2.225,2.225,0,0,0-.125-.71l1.309-1.31A3.96,3.96,0,0,1,14,10,4,4,0,0,1,10,14Z"

--- a/src/icons/Info.tsx
+++ b/src/icons/Info.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Info({ color, size, ...nativeProps }: IconProps) {
+export function Info({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(240 -82)">
           <path

--- a/src/icons/Infringement.tsx
+++ b/src/icons/Infringement.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Infringement({ color, size, ...nativeProps }: IconProps) {
+export function Infringement({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(40 -41)">
           <path

--- a/src/icons/Landmark.tsx
+++ b/src/icons/Landmark.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Landmark({ color, size, ...nativeProps }: IconProps) {
+export function Landmark({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <defs>
           <clipPath>

--- a/src/icons/Link.tsx
+++ b/src/icons/Link.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Link({ color, size, ...nativeProps }: IconProps) {
+export function Link({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M0,0H20V20H0Z" fill="none" />
         <g>

--- a/src/icons/List.tsx
+++ b/src/icons/List.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function List({ color, size, ...nativeProps }: IconProps) {
+export function List({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(160 -41)">
           <g>

--- a/src/icons/MapLayers.tsx
+++ b/src/icons/MapLayers.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function MapLayers({ color, size, ...nativeProps }: IconProps) {
+export function MapLayers({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <g>

--- a/src/icons/MeasureAngle.tsx
+++ b/src/icons/MeasureAngle.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function MeasureAngle({ color, size, ...nativeProps }: IconProps) {
+export function MeasureAngle({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(200 -82)">
           <g>

--- a/src/icons/MeasureBrokenLine.tsx
+++ b/src/icons/MeasureBrokenLine.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function MeasureBrokenLine({ color, size, ...nativeProps }: IconProps) {
+export function MeasureBrokenLine({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(240 -82)">
           <path

--- a/src/icons/MeasureCircle.tsx
+++ b/src/icons/MeasureCircle.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function MeasureCircle({ color, size, ...nativeProps }: IconProps) {
+export function MeasureCircle({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(160 -82)">
           <path

--- a/src/icons/MeasureLine.tsx
+++ b/src/icons/MeasureLine.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function MeasureLine({ color, size, ...nativeProps }: IconProps) {
+export function MeasureLine({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(280 -82)">
           <path

--- a/src/icons/Minus.tsx
+++ b/src/icons/Minus.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Minus({ color, size, ...nativeProps }: IconProps) {
+export function Minus({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="currentColor" height="14" transform="translate(3 11) rotate(-90)" width="2" />
         <rect fill="none" height="20" width="20" />

--- a/src/icons/MissionAction.tsx
+++ b/src/icons/MissionAction.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function MissionAction({ color, size, ...nativeProps }: IconProps) {
+export function MissionAction({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M214,2V0h-2V2h-4V0h-2V2h-3V18h14V2Zm1,14H205V4h10Z" fill="currentColor" transform="translate(-200)" />
         <rect fill="currentColor" height="1.5" transform="translate(7 6.5)" width="6" />

--- a/src/icons/More.tsx
+++ b/src/icons/More.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function More({ color, size, ...nativeProps }: IconProps) {
+export function More({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(240 -41)">
           <g>

--- a/src/icons/Note.tsx
+++ b/src/icons/Note.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Note({ color, size, ...nativeProps }: IconProps) {
+export function Note({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M2,2V18H12l6-6V2ZM4,16V4H16v6H10v6Zm8-.828V12h3.172Z" fill="currentColor" />
         <rect fill="none" height="20" width="20" />

--- a/src/icons/Observation.tsx
+++ b/src/icons/Observation.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Observation({ color, size, ...nativeProps }: IconProps) {
+export function Observation({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <g fill="currentColor" strokeMiterlimit="10">

--- a/src/icons/Phone.tsx
+++ b/src/icons/Phone.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Phone({ color, size, ...nativeProps }: IconProps) {
+export function Phone({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <clipPath>
           <path d="m0 0h20v20h-20z" />

--- a/src/icons/Pin.tsx
+++ b/src/icons/Pin.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Pin({ color, size, ...nativeProps }: IconProps) {
+export function Pin({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-240)">
           <path

--- a/src/icons/PinFilled.tsx
+++ b/src/icons/PinFilled.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function PinFilled({ color, size, ...nativeProps }: IconProps) {
+export function PinFilled({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M10.94,2L9.528,3.412L10.234,4.119L6.7,7.65L3.876,7.65L2.464,9.063L5.982,12.583L1.997,16.583L3.413,18L7.398,14L10.938,17.542L12.351,16.13L12.351,13.3L15.882,9.769L16.588,10.475L18,9.064L10.94,2Z"

--- a/src/icons/Pinpoint.tsx
+++ b/src/icons/Pinpoint.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Pinpoint({ color, size, ...nativeProps }: IconProps) {
+export function Pinpoint({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-160)">
           <path d="M164,8c0,5,6,10,6,10" fill="currentColor" />

--- a/src/icons/PinpointHide.tsx
+++ b/src/icons/PinpointHide.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function PinpointHide({ color, size, ...nativeProps }: IconProps) {
+export function PinpointHide({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-8.128 -10.447)">
           <rect fill="none" height="20" transform="translate(8.128 10.447)" width="20" />

--- a/src/icons/Plane.tsx
+++ b/src/icons/Plane.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Plane({ color, size, ...nativeProps }: IconProps) {
+export function Plane({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M18.5,13.6V11.8L11.342,7.3V2.35a1.342,1.342,0,1,0-2.684,0V7.3L1.5,11.8v1.8l7.158-2.25V16.3l-1.79,1.35V19L10,18.1l3.132.9V17.65l-1.79-1.35V11.35Z"

--- a/src/icons/Plus.tsx
+++ b/src/icons/Plus.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Plus({ color, size, ...nativeProps }: IconProps) {
+export function Plus({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(120 -82)">
           <path d="M-102,91h-7V84h-2v7h-7v2h7v7h2V93h7Z" fill="currentColor" />

--- a/src/icons/Reject.tsx
+++ b/src/icons/Reject.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Reject({ color, size, ...nativeProps }: IconProps) {
+export function Reject({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-80)">
           <path d="M90,1a9,9,0,1,0,9,9A9,9,0,0,0,90,1Zm0,16a7,7,0,1,1,7-7A7,7,0,0,1,90,17Z" fill="currentColor" />

--- a/src/icons/Report.tsx
+++ b/src/icons/Report.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Report({ color, size, ...nativeProps }: IconProps) {
+export function Report({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <path d="M-143,6.6-155,1V19h2V11.453Z" fill="currentColor" transform="translate(160)" />

--- a/src/icons/Rescue.tsx
+++ b/src/icons/Rescue.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Rescue({ color, size, ...nativeProps }: IconProps) {
+export function Rescue({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <clipPath>
           <path d="m0 0h20v20h-20z" />

--- a/src/icons/Reset.tsx
+++ b/src/icons/Reset.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Reset({ color, size, ...nativeProps }: IconProps) {
+export function Reset({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M0,0H20V20H0Z" fill="none" />
         <g>

--- a/src/icons/Save.tsx
+++ b/src/icons/Save.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Save({ color, size, ...nativeProps }: IconProps) {
+export function Save({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M14.444,2H2V18H18V5.556ZM10,16.222a2.667,2.667,0,1,1,2.667-2.667h0a2.663,2.663,0,0,1-2.659,2.667Zm2.667-8.889H3.778V3.778h8.889Z"

--- a/src/icons/Search.tsx
+++ b/src/icons/Search.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Search({ color, size, ...nativeProps }: IconProps) {
+export function Search({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(200 -41)">
           <g fill="none" strokeMiterlimit="10">

--- a/src/icons/SelectCircle.tsx
+++ b/src/icons/SelectCircle.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SelectCircle({ color, size, ...nativeProps }: IconProps) {
+export function SelectCircle({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M0,0H20V20H0Z" fill="none" />
         <path

--- a/src/icons/SelectPolygon.tsx
+++ b/src/icons/SelectPolygon.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SelectPolygon({ color, size, ...nativeProps }: IconProps) {
+export function SelectPolygon({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(120 -41)">
           <g>

--- a/src/icons/SelectRectangle.tsx
+++ b/src/icons/SelectRectangle.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SelectRectangle({ color, size, ...nativeProps }: IconProps) {
+export function SelectRectangle({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(160 -41)">
           <g>

--- a/src/icons/SelectZone.tsx
+++ b/src/icons/SelectZone.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SelectZone({ color, size, ...nativeProps }: IconProps) {
+export function SelectZone({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(80 -41)">
           <g>

--- a/src/icons/Semaphore.tsx
+++ b/src/icons/Semaphore.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Semaphore({ color, size, ...nativeProps }: IconProps) {
+export function Semaphore({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M0,0H20V20H0Z" fill="none" />
         <path d="M0,0H20V20H0Z" fill="none" />

--- a/src/icons/ShowErsMessages.tsx
+++ b/src/icons/ShowErsMessages.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function ShowErsMessages({ color, size, ...nativeProps }: IconProps) {
+export function ShowErsMessages({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-40 -41)">
           <g>

--- a/src/icons/ShowXml.tsx
+++ b/src/icons/ShowXml.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function ShowXml({ color, size, ...nativeProps }: IconProps) {
+export function ShowXml({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-120)">
           <path

--- a/src/icons/SortSelectedDown.tsx
+++ b/src/icons/SortSelectedDown.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SortSelectedDown({ color, size, ...nativeProps }: IconProps) {
+export function SortSelectedDown({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(20 20) rotate(180)">
           <rect fill="none" height="20" width="20" />

--- a/src/icons/SortSelectedUp.tsx
+++ b/src/icons/SortSelectedUp.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SortSelectedUp({ color, size, ...nativeProps }: IconProps) {
+export function SortSelectedUp({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <g transform="translate(0)">

--- a/src/icons/SortingArrows.tsx
+++ b/src/icons/SortingArrows.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SortingArrows({ color, size, ...nativeProps }: IconProps) {
+export function SortingArrows({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-40)">
           <g>

--- a/src/icons/SortingChevrons.tsx
+++ b/src/icons/SortingChevrons.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function SortingChevrons({ color, size, ...nativeProps }: IconProps) {
+export function SortingChevrons({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M-184.5-110.5-190-105l-5.5-5.5"

--- a/src/icons/Summary.tsx
+++ b/src/icons/Summary.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Summary({ color, size, ...nativeProps }: IconProps) {
+export function Summary({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <defs>
           <clipPath>

--- a/src/icons/Tag.tsx
+++ b/src/icons/Tag.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Tag({ color, size, ...nativeProps }: IconProps) {
+export function Tag({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-160)">
           <path d="M173.063,6l3.334,4-3.334,4H164V6h9.063M174,4H162V16h12l5-6-5-6Z" fill="currentColor" />

--- a/src/icons/Target.tsx
+++ b/src/icons/Target.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Target({ color, size, ...nativeProps }: IconProps) {
+export function Target({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g fill="none" strokeMiterlimit="10">
           <path

--- a/src/icons/Unlink.tsx
+++ b/src/icons/Unlink.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Unlink({ color, size, ...nativeProps }: IconProps) {
+export function Unlink({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <rect fill="none" height="20" width="20" />
         <g>

--- a/src/icons/Unlock.tsx
+++ b/src/icons/Unlock.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Unlock({ color, size, ...nativeProps }: IconProps) {
+export function Unlock({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M0,0H20V20H0Z" fill="none" />
         <g>

--- a/src/icons/Vessel.tsx
+++ b/src/icons/Vessel.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Vessel({ color, size, ...nativeProps }: IconProps) {
+export function Vessel({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <g transform="translate(-260 -208)">
           <path

--- a/src/icons/ViewOnMap.tsx
+++ b/src/icons/ViewOnMap.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function ViewOnMap({ color, size, ...nativeProps }: IconProps) {
+export function ViewOnMap({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path
           d="M18.5,1.523l-6,2.4-5-2-6,2.4V18.477l6-2.4,5,2,6-2.4ZM3.5,5.677l3-1.2v9.846l-3,1.2Zm5,8.646V4.477l3,1.2v9.846Zm8,0-3,1.2V5.677l3-1.2Z"

--- a/src/icons/Vms.tsx
+++ b/src/icons/Vms.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Vms({ color, size, ...nativeProps }: IconProps) {
+export function Vms({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M0,0H20V20H0Z" fill="none" />
         <g transform="translate(0 0.329)">

--- a/src/icons/Warning.tsx
+++ b/src/icons/Warning.tsx
@@ -2,9 +2,9 @@ import { IconBox } from '../elements/IconBox'
 
 import type { IconProps } from '../types/definitions'
 
-export function Warning({ color, size, ...nativeProps }: IconProps) {
+export function Warning({ color, size, title, ...nativeProps }: IconProps) {
   return (
-    <IconBox $color={color} $size={size}>
+    <IconBox $color={color} $size={size} title={title}>
       <svg height="20" viewBox="0 0 20 20" width="20" {...nativeProps}>
         <path d="M18,18H2l-.883-1.471,8-15h1.766l8,15ZM3.667,16H16.333L10,4.125Z" fill="currentColor" />
         <rect fill="currentColor" height="4.011" transform="translate(9 7.989)" width="2" />

--- a/src/types/definitions.ts
+++ b/src/types/definitions.ts
@@ -24,6 +24,7 @@ export type IconProps = SVGProps<SVGSVGElement> & {
   color?: string | undefined
   /** In pixels */
   size?: number | undefined
+  title?: string | undefined
 }
 
 export type Filter<T> = (collection: T[]) => T[]

--- a/stories/Icon.stories.tsx
+++ b/stories/Icon.stories.tsx
@@ -8,7 +8,8 @@ import type { Meta } from '@storybook/react'
 
 const args: IconProps = {
   color: THEME.color.charcoal,
-  size: 32
+  size: 32,
+  title: 'any optional text you want'
 }
 
 /* eslint-disable sort-keys-fix/sort-keys-fix */


### PR DESCRIPTION
## Description

Dans le cadre du nouveau statut de mission, on doit maintenant montrer une sorte de title sur les icones comme dans ce screenshot:
<img width="1929" alt="Screenshot 2024-03-21 at 14 13 19" src="https://github.com/MTES-MCT/monitor-ui/assets/4593884/cd9e5cb2-b162-41f6-b0e4-605be8b935ec">

La solution que j'ai retenu, c'était d'ajouter une balise `<title>` dans le SVG dans le script de génération des Icon components. 
J'ai aussi ajouté une prop optionnelle `title` pour les icônes.
L'effet hover n'est pas déclenché quand title est undefined ou empty string.

Ouvert à tout type de feedback pour savoir si c'était le bon endroit pour mettre ça et si je m'y suis bien pris.

PS: déso pour la longueur de la PR mais il a fallu regen toutes les icones. Les fichiers importants sont autour du script de generation.

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-pgbjglibbb.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
