### PR TITLE
fix(components): make banner visible again when isClosable or isColla…

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -46,14 +46,22 @@ function Banner({
   const [isCollapsing, setIsCollapsing] = useState<boolean>(false)
   const [hasCollapsed, setHasCollapsed] = useState<boolean>(false)
 
+  useEffect(() => {
+    // Reset visibility/height when isCollapsible or isClosable change
+    setIsHidden(false)
+    setIsCollapsed(false)
+    setIsCollapsing(false)
+    setHasCollapsed(false)
+  }, [isCollapsible, isClosable])
+
   const enterHover = (): void => {
-    if (!isHidden && isCollapsed && !isCollapsing) {
+    if (isCollapsible && !isHidden && isCollapsed && !isCollapsing) {
       setIsCollapsed(false)
     }
     setIsCollapsing(false)
   }
   const leaveHover = (): void => {
-    if (!isHidden && hasCollapsed) {
+    if (isCollapsible && !isHidden && hasCollapsed) {
       setIsCollapsed(true)
     }
   }


### PR DESCRIPTION
…psible change (rapportnav usecase)

## Description

Côté RapportNav, on peut passer d'un type de banniere à l'autre selon certains cas. Mais la transition était mal supportée comme la video l'indique.


https://github.com/MTES-MCT/monitor-ui/assets/4593884/898e67ba-5860-422c-ba4f-98a5d440168c



## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
_Waiting for deployment..._
<!-- AUTOFILLED_PREVIEW_URL -->
