### PR TITLE
fix(fields): prevent textarea from being horizontally reduced

### DIFF
--- a/src/fields/Textarea.tsx
+++ b/src/fields/Textarea.tsx
@@ -114,6 +114,7 @@ const StyledRsuiteInput = styled(RsuiteInput)<CommonFieldStyleProps>`
   font-weight: 500;
   padding: 7px 8px;
   width: 100%;
+  min-width: 100%;
   max-width: 100%;
 
   &::placeholder {


### PR DESCRIPTION
## Description

Le Textarea peut être réduit en horizontal par l'utilisateur, ce qui est à éviter selon Clémence.

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-olcwcvvdqu.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
