### PR TITLE
fix(components): remove typo in Message class name

### DIFF
--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -15,7 +15,7 @@ export type MessageProps = HTMLAttributes<HTMLDivElement> & {
   level?: Level | undefined
 }
 export function Message({ children, className, Icon, iconColor, level = Level.INFO, ...nativeProps }: MessageProps) {
-  const controlledClassName = classnames('Component-Message>', className)
+  const controlledClassName = classnames('Component-Message', className)
   const ControlledIcon = Icon ?? DEFAUT_ICON[level]
   const controlledIconColor = iconColor ?? DEFAULT_ICON_COLOR[level]
 


### PR DESCRIPTION
## Related Pull Requests & Issues

- MTES-MCT/monitorenv#1271

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-jjeyaytwzy.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
