### PR TITLE
fix(elements)!: switch IconBox wrapper element from a div to a span

### DIFF
--- a/src/components/Dropdown/Item.tsx
+++ b/src/components/Dropdown/Item.tsx
@@ -55,8 +55,7 @@ const PrimaryDropdownItem = styled(RsuiteDropdown.Item as any)<{
   &:not(:last-child) {
     border-bottom: 1px solid var(--lightGray);
   }
-  /* SVG Icon Components are wrapped within a <div />  */
-  > div {
+  > .Element-IconBox {
     margin-top: 1px;
   }
 `

--- a/src/components/Dropdown/index.tsx
+++ b/src/components/Dropdown/index.tsx
@@ -61,8 +61,7 @@ const PrimaryDropdown = styled(RsuiteDropdown as any)<{
       color: ${p => p.theme.color.cultured};
     }
 
-    /* SVG Icon Components are wrapped within a <div /> */
-    > div {
+    > .Element-IconBox {
       margin: 1px 8px 0 0;
     }
 

--- a/src/elements/Button.tsx
+++ b/src/elements/Button.tsx
@@ -108,8 +108,7 @@ const StyledButton = styled.button<{
   padding: ${p => PADDING[p.size]};
   width: ${p => (p.isFullWidth ? '100%' : 'auto')};
 
-  /* SVG Icon Components are wrapped within a <div /> */
-  > div {
+  > .Element-IconBox {
     margin-right: 5px;
   }
 `

--- a/src/elements/IconBox.tsx
+++ b/src/elements/IconBox.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components'
 
 import type { HTMLAttributes } from 'react'
 
-export type IconBoxProps = HTMLAttributes<HTMLDivElement> & {
+export type IconBoxProps = HTMLAttributes<HTMLSpanElement> & {
   $color?: string | undefined
   /** In pixels */
   $size?: number | undefined
@@ -10,7 +10,7 @@ export type IconBoxProps = HTMLAttributes<HTMLDivElement> & {
 /**
  * Internal component used to wrap SVG icon components
  */
-export const IconBox = styled.div.attrs<IconBoxProps, IconBoxProps>(() => ({
+export const IconBox = styled.span.attrs<IconBoxProps, IconBoxProps>(() => ({
   className: 'Element-IconBox'
 }))`
   display: inline-block;

--- a/src/elements/Tag/index.tsx
+++ b/src/elements/Tag/index.tsx
@@ -101,8 +101,8 @@ const Box = styled.span<{
   height: 22px;
   line-height: normal;
   padding: ${p => (p.$withCircleIcon ? '1px 8px 0px 1px' : '0px 8px')};
-  /* SVG Icon components are wrapped within a <div /> */
-  > div {
+
+  > .Element-IconBox {
     margin-right: 4px;
   }
 `


### PR DESCRIPTION
BREAKING CHANGE: `<IconButton />` is now a span instead of a div.

## Related Pull Requests & Issues

- MTES-MCT/monitorenv#1271

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
_Waiting for deployment..._
<!-- AUTOFILLED_PREVIEW_URL -->
