### PR TITLE
feat(tables)!: add $isLoading prop to SimpleTable.Td, normalize all tables margins/heights & checkboxes

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -71,7 +71,7 @@ module.exports = {
         format: ['camelCase', 'PascalCase'],
         prefix: BOOLEAN_CAMEL_PREFIXES,
         filter: {
-          regex: '^(checked|disabled|readOnly|searchable|value)$',
+          regex: '^(_.*|checked|disabled|readOnly|searchable|value)$',
           match: false
         }
       },
@@ -81,7 +81,7 @@ module.exports = {
         format: ['camelCase', 'PascalCase'],
         prefix: BOOLEAN_CAMEL_PREFIXES,
         filter: {
-          regex: '^(checked|disabled|readOnly|searchable|value)$',
+          regex: '^(_.*|checked|disabled|readOnly|searchable|value)$',
           match: false
         }
       },

--- a/config/jest.config.js
+++ b/config/jest.config.js
@@ -22,6 +22,7 @@ export default {
             '@fields/*': ['fields/*'],
             '@hooks/*': ['hooks/*'],
             '@libs/*': ['libs/*'],
+            '@tables/*': ['tables/*'],
             '@types_/*': ['types/*'],
             '@utils/*': ['utils/*']
           },

--- a/src/fields/Checkbox.tsx
+++ b/src/fields/Checkbox.tsx
@@ -45,6 +45,8 @@ export function Checkbox({
   disabled = false,
   error,
   hasError = false,
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  indeterminate = false,
   isErrorMessageHidden = false,
   isLight = false,
   isTransparent = false,
@@ -79,7 +81,7 @@ export function Checkbox({
       <StyledRsuiteCheckbox
         key={key}
         $hasError={hasControlledError}
-        $isChecked={checked}
+        $isChecked={checked || indeterminate}
         $isDisabled={disabled}
         $isLight={isLight}
         $isReadOnly={readOnly}
@@ -87,6 +89,7 @@ export function Checkbox({
         checked={checked}
         disabled={disabled}
         id={name}
+        indeterminate={indeterminate}
         name={name}
         onChange={handleChange}
         readOnly={readOnly}
@@ -100,13 +103,14 @@ export function Checkbox({
   )
 }
 
-const StyledRsuiteCheckbox = styled(RsuiteCheckbox)<CommonChoiceFieldStyleProps>`
+export const StyledRsuiteCheckbox = styled(RsuiteCheckbox)<CommonChoiceFieldStyleProps>`
   * {
     ${p => p.$isReadOnly && `cursor: default !important;`}
     user-select: none;
   }
 
-  > .rs-checkbox-checker {
+  > .rs-checkbox-checker,
+  &.rs-checkbox-indeterminate > .rs-checkbox-checker {
     min-height: unset;
     padding: 0 0 0 24px;
 

--- a/src/tables/SimpleTable/CellLoader.tsx
+++ b/src/tables/SimpleTable/CellLoader.tsx
@@ -11,7 +11,7 @@ const cellLoaderAnimation = keyframes`
 `
 export const CellLoader = styled.div`
   background: ${p => p.theme.color.gainsboro};
-  height: 18px;
+  height: 22px;
   overflow: hidden;
   position: relative;
 

--- a/src/tables/SimpleTable/CellLoader.tsx
+++ b/src/tables/SimpleTable/CellLoader.tsx
@@ -1,0 +1,29 @@
+import styled, { keyframes } from 'styled-components'
+
+const cellLoaderAnimation = keyframes`
+  from {
+    left: -100%;
+  }
+
+  to {
+    left: 100%;
+  }
+`
+export const CellLoader = styled.div`
+  background: ${p => p.theme.color.gainsboro};
+  height: 18px;
+  overflow: hidden;
+  position: relative;
+
+  &:before {
+    animation: ${cellLoaderAnimation} 1s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    background: linear-gradient(to right, transparent 0%, ${p => p.theme.color.white} 50%, transparent 100%);
+    content: '';
+    display: block;
+    height: 100%;
+    left: -100%;
+    position: absolute;
+    top: 0;
+    width: 100%;
+  }
+`

--- a/src/tables/SimpleTable/Td.tsx
+++ b/src/tables/SimpleTable/Td.tsx
@@ -16,6 +16,7 @@ export const Td = styled.td.attrs<TdProps, TdProps>(props => ({
   color: ${p => p.theme.color.gunMetal};
   font-size: 13px;
   font-weight: 500;
+  line-height: 22px;
   max-width: 0;
   overflow: hidden;
   padding: 10px;

--- a/src/tables/SimpleTable/Td.tsx
+++ b/src/tables/SimpleTable/Td.tsx
@@ -1,0 +1,25 @@
+import styled from 'styled-components'
+
+import { CellLoader } from './CellLoader'
+
+import type { TdHTMLAttributes } from 'react'
+
+type TdProps = TdHTMLAttributes<HTMLTableCellElement> & {
+  $isCenter?: boolean | undefined
+  $isLoading?: boolean | undefined
+}
+export const Td = styled.td.attrs<TdProps, TdProps>(props => ({
+  children: props.$isLoading ? <CellLoader /> : props.children
+}))`
+  border-bottom: 1px solid ${p => p.theme.color.lightGray};
+  border-right: 1px solid ${p => p.theme.color.lightGray};
+  color: ${p => p.theme.color.gunMetal};
+  font-size: 13px;
+  font-weight: 500;
+  max-width: 0;
+  overflow: hidden;
+  padding: 10px;
+  text-align: ${p => (p.$isCenter ? 'center' : 'left')};
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`

--- a/src/tables/SimpleTable/Td.tsx
+++ b/src/tables/SimpleTable/Td.tsx
@@ -19,8 +19,17 @@ export const Td = styled.td.attrs<TdProps, TdProps>(props => ({
   line-height: 22px;
   max-width: 0;
   overflow: hidden;
-  padding: 10px;
+  padding: 9px 10px;
   text-align: ${p => (p.$isCenter ? 'center' : 'left')};
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  /**
+    Dirty hack to prevent 'display: inline-flex;' from breaking row height.
+    This may be fixable by internal alignment cleanup in <Tag /> component.
+  */
+  > .Element-Tag {
+    align-self: unset;
+    vertical-align: bottom;
+  }
 `

--- a/src/tables/SimpleTable/index.tsx
+++ b/src/tables/SimpleTable/index.tsx
@@ -34,7 +34,8 @@ const Th = styled.th<{
   color: ${p => p.theme.color.slateGray};
   font-size: 13px;
   font-weight: 500;
-  padding: 10px;
+  line-height: 22px;
+  padding: 9px 10px;
   overflow: hidden;
   text-overflow: ellipsis;
   ${p => !!p.$width && `width: ${p.$width}px;`}

--- a/src/tables/SimpleTable/index.tsx
+++ b/src/tables/SimpleTable/index.tsx
@@ -1,37 +1,32 @@
 import classnames from 'classnames'
 import styled from 'styled-components'
 
+import { CellLoader } from './CellLoader'
+import { Td } from './Td'
+
 import type { TableHTMLAttributes } from 'react'
 
 const Table = styled.table.attrs<TableHTMLAttributes<HTMLTableElement>>(props => ({
   className: classnames('Table-SimpleTable', props.className)
 }))`
-  width: 100%;
-  table-layout: auto;
-  overflow: auto;
   border-collapse: separate;
+  overflow: auto;
+  table-layout: auto;
 `
+
 const Head = styled.thead`
   position: sticky;
   top: 0;
   z-index: 1;
 
-  th:first-child {
+  > th:first-child {
     border-left: 1px solid ${p => p.theme.color.lightGray};
   }
 `
 
-const SortContainer = styled.div`
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  cursor: default;
-
-  &.cursor-pointer {
-    cursor: pointer;
-  }
-`
-const Th = styled.th`
+const Th = styled.th<{
+  $width?: number | undefined
+}>`
   background-color: ${p => p.theme.color.gainsboro};
   border-top: 1px solid ${p => p.theme.color.lightGray};
   border-bottom: 1px solid ${p => p.theme.color.lightGray};
@@ -42,35 +37,35 @@ const Th = styled.th`
   padding: 10px;
   overflow: hidden;
   text-overflow: ellipsis;
+  ${p => !!p.$width && `width: ${p.$width}px;`}
   white-space: nowrap;
 `
 
+const SortContainer = styled.div`
+  align-items: center;
+  cursor: default;
+  display: flex;
+  justify-content: space-between;
+
+  &.cursor-pointer {
+    cursor: pointer;
+  }
+`
+
 const BodyTr = styled.tr`
-  :hover {
+  &:hover {
     > td {
       background-color: ${p => p.theme.color.blueYonder25};
     }
   }
-  td:first-child {
+  > td:first-child {
     border-left: 1px solid ${p => p.theme.color.lightGray};
   }
 `
 
-const Td = styled.td<{ $isCenter?: boolean }>`
-  font-size: 13px;
-  font-weight: 500;
-  color: ${p => p.theme.color.gunMetal};
-  text-align: ${p => (p.$isCenter ? 'center' : 'left')};
-  border-bottom: 1px solid ${p => p.theme.color.lightGray};
-  border-right: 1px solid ${p => p.theme.color.lightGray};
-  overflow: hidden;
-  padding: 10px;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-`
-
 export const SimpleTable = {
   BodyTr,
+  CellLoader,
   Head,
   SortContainer,
   Table,

--- a/src/tables/TableWithSelectableRows/RowCheckbox.tsx
+++ b/src/tables/TableWithSelectableRows/RowCheckbox.tsx
@@ -1,31 +1,67 @@
+import { StyledRsuiteCheckbox } from '@fields/Checkbox'
 import { stopMouseEventPropagation } from '@utils/stopMouseEventPropagation'
-import { type HTMLProps } from 'react'
-import { Checkbox as RsuiteCheckbox } from 'rsuite'
+import { useCallback, type ChangeEvent, type HTMLProps } from 'react'
+import { type CheckboxProps as RsuiteCheckboxProps } from 'rsuite'
+import styled from 'styled-components'
 
-export type RowCheckboxProps = {
-  className?: string
-  disabled?: boolean
-  isChecked?: boolean
-  // handle the case where some child checkboxes are checked to display an indeterminate style (-)
-  isIndeterminate?: boolean
-  onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+import type { ValueType } from 'rsuite/esm/Checkbox'
+
+export type RowCheckboxProps = Omit<RsuiteCheckboxProps, 'onClick' | 'onChange'> & {
+  // TODO Maybe replace that with a `((isChecked: boolean) => Promisable<void>) | undefined` for consistency with other boolean fields?
+  onChange?: ((event: ChangeEvent<HTMLInputElement>) => void) | undefined
 }
-export function RowCheckbox({
-  className = '',
-  disabled = false,
-  isChecked = false,
-  isIndeterminate = false,
-  onChange = () => undefined
-}: RowCheckboxProps & HTMLProps<HTMLInputElement>) {
+export function RowCheckbox({ onChange, ...nativeProps }: RowCheckboxProps & HTMLProps<HTMLInputElement>) {
+  const handleOnChange = useCallback(
+    (_value: ValueType | undefined, _checked: boolean, event: ChangeEvent<HTMLInputElement>) => {
+      if (onChange) {
+        onChange(event)
+      }
+    },
+    [onChange]
+  )
+
   return (
-    <RsuiteCheckbox
-      checked={isChecked}
-      className={`${className} cursor-pointer`}
-      disabled={disabled}
-      indeterminate={isIndeterminate}
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      onChange={(_, __, event) => onChange(event)}
+    <RestyledRsuiteCheckbox
+      $isChecked={nativeProps.checked || nativeProps.indeterminate}
+      $isDisabled={nativeProps.disabled}
+      $isReadOnly={nativeProps.readOnly}
+      {...nativeProps}
+      onChange={handleOnChange}
       onClick={stopMouseEventPropagation}
     />
   )
 }
+
+const RestyledRsuiteCheckbox = styled(StyledRsuiteCheckbox)`
+  vertical-align: top;
+
+  > .rs-checkbox-checker,
+  &.rs-checkbox-indeterminate > .rs-checkbox-checker {
+    padding: 0;
+
+    > label {
+      > .rs-checkbox-wrapper {
+        bottom: 0;
+        top: 3px;
+
+        &:before {
+        }
+        &:after {
+          bottom: 0;
+          left: 0;
+          right: 0;
+          top: 0;
+        }
+
+        > .rs-checkbox-inner {
+          &:before {
+          }
+
+          /* Checkmark */
+          &:after {
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/tables/TableWithSelectableRows/index.tsx
+++ b/src/tables/TableWithSelectableRows/index.tsx
@@ -3,58 +3,64 @@ import styled from 'styled-components'
 import { RowCheckbox } from './RowCheckbox'
 import { SimpleTable } from '../SimpleTable'
 
-export { RowCheckbox }
-
 const Table = styled(SimpleTable.Table)`
   border-collapse: separate;
   border-spacing: 0 5px;
   table-layout: fixed;
 `
+
 const Head = styled(SimpleTable.Head)`
-  th:last-child {
+  > th:last-child {
     border-right: 1px solid ${p => p.theme.color.lightGray};
   }
 `
 
-const SortContainer = styled(SimpleTable.SortContainer)`
-  justify-content: start;
-  gap: 8px;
-`
-const Th = styled(SimpleTable.Th)<{ $width: number }>`
+const Th = styled(SimpleTable.Th)`
   background-color: ${p => p.theme.color.white};
   border-top: 1px solid ${p => p.theme.color.lightGray};
   border-bottom: 1px solid ${p => p.theme.color.lightGray};
   border-right: none;
   padding: 2px 16px;
-  width: ${p => p.$width}px;
+`
+
+const SortContainer = styled(SimpleTable.SortContainer)`
+  gap: 8px;
+  justify-content: start;
 `
 
 const BodyTr = styled(SimpleTable.BodyTr)<{ $isHighlighted?: boolean }>`
-  td:first-child {
+  > td:first-child {
     border-left: ${p =>
       p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
   }
-  td:last-child {
+  > td:last-child {
     border-right: ${p =>
       p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
     overflow: visible;
   }
 `
 
-const Td = styled(SimpleTable.Td)<{ $hasRightBorder: boolean; $isHighlighted?: boolean; $width: number }>`
+const Td = styled(SimpleTable.Td)<{
+  $hasRightBorder: boolean
+  $isHighlighted?: boolean
+  // TODO This should be removed, a table column width should only be set via its `th` width.
+  /** @deprecated Will be removed in the next major version. Use `Td.$width` instead to set columns width. */
+  $width?: number | undefined
+}>`
   background-color: ${p => p.theme.color.cultured};
-  border-top: ${p =>
-    p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
   border-bottom: ${p =>
     p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
   border-right: none;
-  padding: 4px 16px;
   border-right: ${p => (p.$hasRightBorder ? `1px solid ${p.theme.color.lightGray}` : '')};
+  border-top: ${p =>
+    p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
+  padding: 4px 16px;
   width: ${p => p.$width}px;
 `
 
 export const TableWithSelectableRows = {
   BodyTr,
+  CellLoader: SimpleTable.CellLoader,
   Head,
   RowCheckbox,
   SortContainer,

--- a/src/tables/TableWithSelectableRows/index.tsx
+++ b/src/tables/TableWithSelectableRows/index.tsx
@@ -3,24 +3,58 @@ import styled from 'styled-components'
 import { RowCheckbox } from './RowCheckbox'
 import { SimpleTable } from '../SimpleTable'
 
-const Table = styled(SimpleTable.Table)`
+const Table = styled(SimpleTable.Table)<{
+  $withRowCheckbox?: boolean
+}>`
   border-collapse: separate;
   border-spacing: 0 5px;
   table-layout: fixed;
+
+  ${p =>
+    !!p.$withRowCheckbox &&
+    `
+      > thead > tr > th:first-child {
+        padding: 0 0 0 8px;
+
+        > .rs-checkbox {
+          > .rs-checkbox-checker {
+            > label {
+              > .rs-checkbox-wrapper {
+                left: -8px;
+              }
+            }
+          }
+        }
+      }
+
+      > tbody > tr > td:first-child {
+        padding: 0 0 0 8px;
+      }
+  `}
 `
 
 const Head = styled(SimpleTable.Head)`
-  > th:last-child {
-    border-right: 1px solid ${p => p.theme.color.lightGray};
+  > tr {
+    > th {
+      border-bottom: 1px solid ${p => p.theme.color.lightGray};
+      border-right: none;
+      border-top: 1px solid ${p => p.theme.color.lightGray};
+
+      &:first-child {
+        border-left: 1px solid ${p => p.theme.color.lightGray};
+      }
+
+      &:last-child {
+        border-right: 1px solid ${p => p.theme.color.lightGray};
+      }
+    }
   }
 `
 
 const Th = styled(SimpleTable.Th)`
   background-color: ${p => p.theme.color.white};
-  border-top: 1px solid ${p => p.theme.color.lightGray};
-  border-bottom: 1px solid ${p => p.theme.color.lightGray};
-  border-right: none;
-  padding: 2px 16px;
+  line-height: 22px;
+  padding: 9px 16px;
 `
 
 const SortContainer = styled(SimpleTable.SortContainer)`
@@ -28,34 +62,40 @@ const SortContainer = styled(SimpleTable.SortContainer)`
   justify-content: start;
 `
 
-const BodyTr = styled(SimpleTable.BodyTr)<{ $isHighlighted?: boolean }>`
-  > td:first-child {
-    border-left: ${p =>
-      p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
-  }
-  > td:last-child {
-    border-right: ${p =>
-      p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
-    overflow: visible;
+const BodyTr = styled(SimpleTable.BodyTr)<{
+  $isHighlighted?: boolean
+}>`
+  > td {
+    border-bottom: 1px solid ${p => (p.$isHighlighted ? p.theme.color.blueGray : p.theme.color.lightGray)};
+    border-right: none;
+    border-top: 1px solid ${p => (p.$isHighlighted ? p.theme.color.blueGray : p.theme.color.lightGray)};
+    ${p =>
+      !!p.$isHighlighted &&
+      `box-shadow: 0 -1px 0 ${p.theme.color.blueGray} inset, 0 1px 0 ${p.theme.color.blueGray} inset;`}
+
+    &:first-child {
+      border-left: 1px solid ${p => (p.$isHighlighted ? p.theme.color.blueGray : p.theme.color.lightGray)};
+      ${p =>
+        !!p.$isHighlighted &&
+        `box-shadow: 0 -1px 0 ${p.theme.color.blueGray} inset, 0 1px 0 ${p.theme.color.blueGray} inset, 1px 0 0 ${p.theme.color.blueGray} inset;`}
+    }
+
+    &:last-child {
+      border-right: 1px solid ${p => (p.$isHighlighted ? p.theme.color.blueGray : p.theme.color.lightGray)};
+      ${p =>
+        !!p.$isHighlighted &&
+        `box-shadow: 0 -1px 0 ${p.theme.color.blueGray} inset, 0 1px 0 ${p.theme.color.blueGray} inset, -1px 0 0 ${p.theme.color.blueGray} inset;`}
+      overflow: visible;
+    }
   }
 `
 
 const Td = styled(SimpleTable.Td)<{
-  $hasRightBorder: boolean
-  $isHighlighted?: boolean
-  // TODO This should be removed, a table column width should only be set via its `th` width.
-  /** @deprecated Will be removed in the next major version. Use `Td.$width` instead to set columns width. */
-  $width?: number | undefined
+  $hasRightBorder?: boolean
 }>`
   background-color: ${p => p.theme.color.cultured};
-  border-bottom: ${p =>
-    p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
-  border-right: none;
-  border-right: ${p => (p.$hasRightBorder ? `1px solid ${p.theme.color.lightGray}` : '')};
-  border-top: ${p =>
-    p.$isHighlighted ? `2px solid ${p.theme.color.blueGray}` : `1px solid ${p.theme.color.lightGray}`};
-  padding: 4px 16px;
-  width: ${p => p.$width}px;
+  ${p => !!p.$hasRightBorder && `border-right: 1px solid ${p.theme.color.lightGray};`}
+  padding: 9px 16px;
 `
 
 export const TableWithSelectableRows = {

--- a/stories/fields/CheckPicker/WithCustomSearch.stories.tsx
+++ b/stories/fields/CheckPicker/WithCustomSearch.stories.tsx
@@ -57,7 +57,7 @@ const meta: Meta<CheckPickerProps<{}>> = {
 
 export default meta
 
-export function _CheckPickerWithCustomSearch(props: CheckPickerProps<Specy>) {
+export function WithCustomSearch(props: CheckPickerProps<Specy>) {
   const optionsRef = useRef(
     (SPECIES as Specy[]).map(specy => ({
       label: `${specy.code} - ${specy.name}`,

--- a/stories/fields/MultiCascader/WithThreeColumns.stories.tsx
+++ b/stories/fields/MultiCascader/WithThreeColumns.stories.tsx
@@ -30,7 +30,7 @@ const args: MultiCascaderProps<FakeCity> = {
 /* eslint-disable sort-keys-fix/sort-keys-fix */
 const meta: Meta<MultiCascaderProps<FakeCity>> = {
   title: 'Fields/MultiCascader (variations)',
-  component: MultiCascaderWithThreeColumns,
+  component: MultiCascader,
 
   argTypes: {
     value: {
@@ -53,7 +53,7 @@ const meta: Meta<MultiCascaderProps<FakeCity>> = {
 
 export default meta
 
-export function MultiCascaderWithThreeColumns(props: MultiCascaderProps<FakeCity>) {
+export function WithThreeColumns(props: MultiCascaderProps<FakeCity>) {
   const [outputValue, setOutputValue] = useState<FakeCity[] | undefined | '∅'>(props.value ?? '∅')
 
   const { controlledOnChange, controlledValue } = useFieldControl(props.value, setOutputValue)

--- a/stories/fields/MultiSelect/WithCustomSearch.stories.tsx
+++ b/stories/fields/MultiSelect/WithCustomSearch.stories.tsx
@@ -52,7 +52,7 @@ const meta: Meta<MultiSelectProps<Specy>> = {
 
 export default meta
 
-export function MultiSelectWithCustomSearch(props: MultiSelectProps<Specy>) {
+export function WithCustomSearch(props: MultiSelectProps<Specy>) {
   const optionsRef = useRef(
     (SPECIES as Specy[]).map(specy => ({
       label: `${specy.code} - ${specy.name}`,

--- a/stories/fields/Select/WithCustomSearch.stories.tsx
+++ b/stories/fields/Select/WithCustomSearch.stories.tsx
@@ -51,7 +51,7 @@ const meta: Meta<SelectProps<Specy>> = {
 
 export default meta
 
-export function SelectWithCustomSearch(props: SelectProps<Specy>) {
+export function WithCustomSearch(props: SelectProps<Specy>) {
   const optionsRef = useRef(
     (SPECIES as Specy[]).map(specy => ({
       label: `${specy.code} - ${specy.name}`,

--- a/stories/tables/SimpleTable/WithLoader.stories.tsx
+++ b/stories/tables/SimpleTable/WithLoader.stories.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react'
 
 import { META_DEFAULTS } from '../../../.storybook/constants'
 import { generateStoryDecorator } from '../../../.storybook/utils/generateStoryDecorator'
-import { SimpleTable } from '../../../src'
+import { Icon, IconButton, SimpleTable, Size } from '../../../src'
 
 import type { Meta } from '@storybook/react'
 
@@ -45,12 +45,14 @@ export function WithLoader() {
         <SimpleTable.Th $width={48}>ID</SimpleTable.Th>
         <SimpleTable.Th $width={240}>Name</SimpleTable.Th>
         <SimpleTable.Th $width={480}>Address</SimpleTable.Th>
+        <SimpleTable.Th $width={44} />
       </SimpleTable.Head>
       <tbody>
         {isLoading &&
           emptyRows.map((_, index) => (
             // eslint-disable-next-line react/no-array-index-key
             <SimpleTable.BodyTr key={`row-${index}`}>
+              <SimpleTable.Td $isLoading />
               <SimpleTable.Td $isLoading />
               <SimpleTable.Td $isLoading />
               <SimpleTable.Td $isLoading />
@@ -62,6 +64,9 @@ export function WithLoader() {
               <SimpleTable.Td>{brewery.id}</SimpleTable.Td>
               <SimpleTable.Td>{brewery.name}</SimpleTable.Td>
               <SimpleTable.Td>{`${brewery.street}, ${brewery.city} ${brewery.postalCode}, ${brewery.state}`}</SimpleTable.Td>
+              <SimpleTable.Td>
+                <IconButton Icon={Icon.Check} size={Size.SMALL} />
+              </SimpleTable.Td>
             </SimpleTable.BodyTr>
           ))}
       </tbody>

--- a/stories/tables/SimpleTable/WithLoader.stories.tsx
+++ b/stories/tables/SimpleTable/WithLoader.stories.tsx
@@ -1,0 +1,70 @@
+import ky from 'ky'
+import { useEffect, useState } from 'react'
+
+import { META_DEFAULTS } from '../../../.storybook/constants'
+import { generateStoryDecorator } from '../../../.storybook/utils/generateStoryDecorator'
+import { SimpleTable } from '../../../src'
+
+import type { Meta } from '@storybook/react'
+
+/* eslint-disable sort-keys-fix/sort-keys-fix */
+const meta: Meta<{}> = {
+  ...META_DEFAULTS,
+
+  title: 'Tables/SimpleTable (variations)',
+
+  decorators: [
+    generateStoryDecorator({
+      withBackgroundButton: true
+    })
+  ]
+}
+/* eslint-enable sort-keys-fix/sort-keys-fix */
+
+export default meta
+
+export function WithLoader() {
+  const [data, setData] = useState<any[] | undefined>(undefined)
+
+  const emptyRows = new Array(10).fill(undefined)
+  const isLoading = !data
+
+  useEffect(() => {
+    const timer = setTimeout(async () => {
+      const nextData: any = await ky.get('https://api.openbrewerydb.org/v1/breweries?per_page=10').json()
+
+      setData(nextData)
+    }, 5000)
+
+    return () => clearTimeout(timer)
+  }, [])
+
+  return (
+    <SimpleTable.Table>
+      <SimpleTable.Head>
+        <SimpleTable.Th $width={48}>ID</SimpleTable.Th>
+        <SimpleTable.Th $width={240}>Name</SimpleTable.Th>
+        <SimpleTable.Th $width={480}>Address</SimpleTable.Th>
+      </SimpleTable.Head>
+      <tbody>
+        {isLoading &&
+          emptyRows.map((_, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <SimpleTable.BodyTr key={`row-${index}`}>
+              <SimpleTable.Td $isLoading />
+              <SimpleTable.Td $isLoading />
+              <SimpleTable.Td $isLoading />
+            </SimpleTable.BodyTr>
+          ))}
+        {!isLoading &&
+          data?.map(brewery => (
+            <SimpleTable.BodyTr key={brewery.id}>
+              <SimpleTable.Td>{brewery.id}</SimpleTable.Td>
+              <SimpleTable.Td>{brewery.name}</SimpleTable.Td>
+              <SimpleTable.Td>{`${brewery.street}, ${brewery.city} ${brewery.postalCode}, ${brewery.state}`}</SimpleTable.Td>
+            </SimpleTable.BodyTr>
+          ))}
+      </tbody>
+    </SimpleTable.Table>
+  )
+}

--- a/stories/tables/TableWithSelectableRows.stories.tsx
+++ b/stories/tables/TableWithSelectableRows.stories.tsx
@@ -11,7 +11,7 @@ import { Link } from '../../src/icons'
 
 import type { Meta } from '@storybook/react'
 
-const fakeData1 = Array(100).fill({
+const fakeData1 = Array(5).fill({
   actionTaken: null,
   controlUnitId: null,
   createdAt: '2023-08-04T15:13:43.296Z',
@@ -48,7 +48,7 @@ const fakeData1 = Array(100).fill({
   validityTime: 1,
   vehicleType: null
 })
-const fakeData2 = Array(100).fill({
+const fakeData2 = Array(5).fill({
   actionTaken: 'ACTION TAKEN',
   controlUnitId: null,
   createdAt: '2023-08-01T15:13:01.073587Z',
@@ -127,21 +127,26 @@ export function _TableWithSelectableRows() {
         accessorFn: row => row.reportingId,
         cell: ({ row }) => (
           <TableWithSelectableRows.RowCheckbox
+            checked={row.getIsSelected()}
             disabled={!row.getCanSelect()}
-            isChecked={row.getIsSelected()}
             onChange={row.getToggleSelectedHandler(row)}
           />
         ),
         enableSorting: false,
         header: ({ table }) => (
           <TableWithSelectableRows.RowCheckbox
-            isChecked={table.getIsAllRowsSelected()}
-            isIndeterminate={table.getIsSomeRowsSelected()}
+            checked={table.getIsAllRowsSelected()}
+            indeterminate={(() => {
+              console.log('indeterminate', table.getIsSomeRowsSelected())
+
+              return table.getIsSomeRowsSelected()
+            })()}
             onChange={table.getToggleAllRowsSelectedHandler()}
           />
         ),
         id: 'select',
-        size: 25
+
+        size: 25 // 24px + 1px to avoid cutting the right border
       },
       {
         accessorFn: row => row.reportingId,
@@ -221,7 +226,7 @@ export function _TableWithSelectableRows() {
         enableSorting: false,
         header: () => '',
         id: 'missionId',
-        size: 85
+        size: 120
       },
       {
         accessorFn: row => row.geom,
@@ -238,12 +243,17 @@ export function _TableWithSelectableRows() {
         enableSorting: false,
         header: () => '',
         id: 'actionStatus',
-        size: 85
+        size: 112
       },
       {
         accessorFn: row => row.geom,
         cell: info => (
-          <IconButton accent={Accent.TERTIARY} Icon={Icon.FocusZones} onClick={() => console.log(info.getValue())} />
+          <IconButton
+            accent={Accent.TERTIARY}
+            Icon={Icon.FocusZones}
+            isCompact
+            onClick={() => console.log(info.getValue())}
+          />
         ),
         enableSorting: false,
         header: () => '',
@@ -321,13 +331,14 @@ export function _TableWithSelectableRows() {
         <IconButton accent={Accent.SECONDARY} Icon={Icon.Archive} onClick={archiveReportings} />
       </div>
       <div ref={tableContainerRef} style={{ width: 1776 }}>
-        <TableWithSelectableRows.Table>
+        <TableWithSelectableRows.Table $withRowCheckbox>
           <TableWithSelectableRows.Head>
             {table.getHeaderGroups().map(headerGroup => (
               <tr key={headerGroup.id}>
                 {headerGroup.headers.map(header => (
                   <TableWithSelectableRows.Th key={header.id} $width={header.column.getSize()}>
-                    {header.isPlaceholder ? undefined : (
+                    {header.id === 'select' && flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.id !== 'select' && !header.isPlaceholder && (
                       <TableWithSelectableRows.SortContainer
                         className={header.column.getCanSort() ? 'cursor-pointer' : ''}
                         onClick={header.column.getToggleSortingHandler()}
@@ -335,8 +346,8 @@ export function _TableWithSelectableRows() {
                         {flexRender(header.column.columnDef.header, header.getContext())}
                         {header.column.getCanSort() &&
                           ({
-                            asc: <div>▲</div>,
-                            desc: <div>▼</div>
+                            asc: <Icon.SortSelectedDown size={14} />,
+                            desc: <Icon.SortSelectedUp size={14} />
                           }[header.column.getIsSorted() as string] ?? <Icon.SortingArrows size={14} />)}
                       </TableWithSelectableRows.SortContainer>
                     )}
@@ -361,8 +372,6 @@ export function _TableWithSelectableRows() {
                       key={cell.id}
                       $hasRightBorder={!!(cell.column.id === 'geom')}
                       $isCenter={!!(cell.column.id === 'geom' || cell.column.id === 'id')}
-                      $isHighlighted={index % 2 === 0}
-                      $width={cell.column.getSize()}
                     >
                       {flexRender(cell.column.columnDef.cell, cell.getContext())}
                     </TableWithSelectableRows.Td>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
       "@fields/*": ["fields/*"],
       "@hooks/*": ["hooks/*"],
       "@libs/*": ["libs/*"],
+      "@tables/*": ["tables/*"],
       "@types_/*": ["types/*"],
       "@utils/*": ["utils/*"]
     },


### PR DESCRIPTION
## BREAKING CHANGES

- Remove `isChecked` prop in `TableWithSelectableRows.RowCheckbox`, replaced by native `checked` prop.
- Remove `isIndeterminate` prop in `TableWithSelectableRows.RowCheckbox`, replaced by original Rsuite `indeterminate` prop.
- Remove `$isHighlighted` prop in `TableWithSelectableRows.Td`, replaced by the same prop on `TableWithSelectableRows.BodyTr`.
- In order to work properly with `RowCheckbox`, `TableWithSelectableRows` now requires `<Table $withRowCheckbox />`.
- Following the `SimpleTable` & `TableWithSelectableRows` margins/heights normalization, including a few hacks,
  it may break some UI widths & heights.
- Please check `TableWithSelectableRows.stories.tsx` to see a full example on how to use/update it.
- As shown in the story, be careful **NOT** to wrap the checkbox table header cell
  within `<TableWithSelectableRows.SortContainer />` since the flex display breaks its internal positioning.

## Features

- add `$isLoading` prop to `SimpleTable.Td (& `TableWithSelectableRows.Td`)
- add `$width` prop to `SimpleTable.Th` (& `TableWithSelectableRows.Th`)
- add & expose `SimpleTable.CellLoader` (& `TableWithSelectableRows.CellLoader`)
- normalize all heights in tables to 22px inside / 42px outside
- follow new compact design for relatively responsive design:  
  https://xd.adobe.com/view/e5dc3e34-ae1f-4a6d-be9a-5d2a70e54eff-b08f/screen/fefd4bd0-176f-4fad-8247-1603a57564f6/specs/

## Fixes
- fix ellipsis when `SimpleTable.Th` width is set while not set in `SimpleTable.Td` (// `TableWithSelectableRows`)
- ~~deprecate `$width` prop from `TableWithSelectableRows.Td`~~ (removed by breaking change)

## Related Pull Requests & Issues

- MTES-MCT/monitorfish#2843

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-bebahrewee.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->

## Screenshots

![image](https://github.com/MTES-MCT/monitor-ui/assets/5957876/100c40e0-632c-4816-b103-f7f89ccb296f)

![image](https://github.com/MTES-MCT/monitor-ui/assets/5957876/954dac62-5347-4e78-af17-de2a78727290)

