### PR TITLE
build(dev-deps)!: stabilize @tanstack/react-virtual from beta to 3.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "@swc/core": "1.6.13",
     "@swc/jest": "0.2.36",
     "@tanstack/react-table": "8.20.1",
-    "@tanstack/react-virtual": "beta",
+    "@tanstack/react-virtual": "3.8.4",
     "@testing-library/react": "16.0.0",
     "@types/diacritics": "1.3.3",
     "@types/jabber": "1.2.4",
@@ -159,6 +159,8 @@
   },
   "peerDependencies": {
     "@sentry/react": "^8.0.0",
+    "@tanstack/react-table": "^8.0.0",
+    "@tanstack/react-virtual": "^3.0.0",
     "cypress": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
     "formik": "^2.0.0",
     "react": "^18.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3338,7 +3338,7 @@ __metadata:
     "@swc/core": "npm:1.6.13"
     "@swc/jest": "npm:0.2.36"
     "@tanstack/react-table": "npm:8.20.1"
-    "@tanstack/react-virtual": "npm:beta"
+    "@tanstack/react-virtual": "npm:3.8.4"
     "@testing-library/react": "npm:16.0.0"
     "@types/diacritics": "npm:1.3.3"
     "@types/jabber": "npm:1.2.4"
@@ -3419,6 +3419,8 @@ __metadata:
     yup: "npm:1.4.0"
   peerDependencies:
     "@sentry/react": ^8.0.0
+    "@tanstack/react-table": ^8.0.0
+    "@tanstack/react-virtual": ^3.0.0
     cypress: ^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0
     formik: ^2.0.0
     react: ^18.0.0
@@ -6329,15 +6331,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/react-virtual@npm:beta":
-  version: 3.0.0-beta.68
-  resolution: "@tanstack/react-virtual@npm:3.0.0-beta.68"
+"@tanstack/react-virtual@npm:3.8.4":
+  version: 3.8.4
+  resolution: "@tanstack/react-virtual@npm:3.8.4"
   dependencies:
-    "@tanstack/virtual-core": "npm:3.0.0-beta.68"
+    "@tanstack/virtual-core": "npm:3.8.4"
   peerDependencies:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-  checksum: 8c0afe5c476670093807cced5425bd6aad07ffef9b6823c75589eeefdbdd124b1c05766df9337bd6f92a7691c57a8c462c47c80a57d90bccedb9f19215797b76
+  checksum: 2c803a0fd9101c75666b894d455c0c793bc50df4b5039e2bc748c4c50b64ec4ebaf3de990ab711d396ad8cd0582ca1858c7d0132d7f72acb57dfd9721464186e
   languageName: node
   linkType: hard
 
@@ -6348,10 +6350,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/virtual-core@npm:3.0.0-beta.68":
-  version: 3.0.0-beta.68
-  resolution: "@tanstack/virtual-core@npm:3.0.0-beta.68"
-  checksum: 24288d83bbdddc6fc67ac6b1d1879fa159115cac829c0b36bb6e89c46b85d7bb5c60c3bb2256f96790fee2d13aa8227d7b9fbf20bfd94c3249dd21b506ae23df
+"@tanstack/virtual-core@npm:3.8.4":
+  version: 3.8.4
+  resolution: "@tanstack/virtual-core@npm:3.8.4"
+  checksum: 32b3d7c7d7c380992730f38efe171eddb4841a3f9bdac198ff6f6e7c00da0e22d2984d57dcb27895f234768accb5625fc04946aa8745c22a136b3f31941d42ac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
BREAKING CHANGE:
- @tanstack/react-table is added as a peer dependency set to v^8.0.0.
- @tanstack/react-virtual is added as a peer dependency set to v^3.0.0.

## Related Pull Requests & Issues

None.

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-xytrxnmuhs.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
