### PR TITLE
fix(elements): add missing prefixes to styled components props

### DIFF
--- a/src/elements/Button.tsx
+++ b/src/elements/Button.tsx
@@ -97,16 +97,16 @@ const PADDING: Record<Size, string> = {
   [Size.SMALL]: '5px 8px 4px'
 }
 const StyledButton = styled.button<{
-  isFullWidth: boolean
-  size: Size
+  $isFullWidth: boolean
+  $size: Size
 }>`
   align-items: center;
   display: inline-flex;
-  font-size: ${p => FONT_SIZE[p.size]};
+  font-size: ${p => FONT_SIZE[p.$size]};
   justify-content: center;
   max-width: 100%;
-  padding: ${p => PADDING[p.size]};
-  width: ${p => (p.isFullWidth ? '100%' : 'auto')};
+  padding: ${p => PADDING[p.$size]};
+  width: ${p => (p.$isFullWidth ? '100%' : 'auto')};
 
   > .Element-IconBox {
     margin-right: 5px;

--- a/src/elements/Label.tsx
+++ b/src/elements/Label.tsx
@@ -4,18 +4,18 @@ import styled from 'styled-components'
 import type { LabelHTMLAttributes } from 'react'
 
 export type LabelProps = LabelHTMLAttributes<HTMLLabelElement> & {
+  $hasError?: boolean | undefined
+  $idDisabled?: boolean | undefined
+  $isHidden?: boolean | undefined
   $isRequired?: boolean | undefined
-  disabled?: boolean | undefined
-  hasError?: boolean | undefined
-  isHidden?: boolean | undefined
 }
 export const Label = styled.label.attrs<LabelProps, LabelProps>(props => ({
   className: classnames('Element-Label', props.className)
 }))`
   color: ${p =>
     // eslint-disable-next-line no-nested-ternary
-    p.disabled ? p.theme.color.lightGray : p.hasError ? p.theme.color.maximumRed : p.theme.color.slateGray};
-  display: ${p => (p.isHidden ? 'none' : 'block')};
+    p.$idDisabled ? p.theme.color.lightGray : p.$hasError ? p.theme.color.maximumRed : p.theme.color.slateGray};
+  display: ${p => (p.$isHidden ? 'none' : 'block')};
   font-size: 13px;
   line-height: 1.3846;
   margin-bottom: 4px;

--- a/src/fields/CheckPicker.tsx
+++ b/src/fields/CheckPicker.tsx
@@ -127,7 +127,7 @@ export function CheckPicker<OptionValue extends OptionValueType = string>({
 
   return (
     <Field className={controlledClassName} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={originalProps.name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={originalProps.name}>
         {label}
       </Label>
 

--- a/src/fields/MultiCascader/index.tsx
+++ b/src/fields/MultiCascader/index.tsx
@@ -100,7 +100,7 @@ export function MultiCascader<OptionValue extends OptionValueType = string>({
 
   return (
     <Field className={controlledClassName} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={originalProps.name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={originalProps.name}>
         {label}
       </Label>
 

--- a/src/fields/MultiSelect.tsx
+++ b/src/fields/MultiSelect.tsx
@@ -128,7 +128,7 @@ export function MultiSelect<OptionValue extends OptionValueType = string>({
 
   return (
     <Field className={controlledClassName} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={originalProps.name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={originalProps.name}>
         {label}
       </Label>
 

--- a/src/fields/NumberInput.tsx
+++ b/src/fields/NumberInput.tsx
@@ -107,7 +107,7 @@ export function NumberInput({
 
   return (
     <Field className={controlledClassname} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={name}>
         {label}
       </Label>
 

--- a/src/fields/PhoneInput.tsx
+++ b/src/fields/PhoneInput.tsx
@@ -63,7 +63,7 @@ export const PhoneInput = forwardRef<HTMLInputElement, PhoneInputProps>(
 
     return (
       <Field className="Field-PhoneInput">
-        <Label $isRequired={isRequired} disabled={disabled} htmlFor={name} isHidden={isLabelHidden}>
+        <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={name}>
           {label}
         </Label>
         <StyledIMaskInput

--- a/src/fields/Search.tsx
+++ b/src/fields/Search.tsx
@@ -187,7 +187,7 @@ export function Search<OptionValue extends OptionValueType = string>({
 
   return (
     <Field className={controlledClassName} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={originalProps.name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={originalProps.name}>
         {label}
       </Label>
 

--- a/src/fields/Select.tsx
+++ b/src/fields/Select.tsx
@@ -141,7 +141,7 @@ export function Select<OptionValue extends OptionValueType = string>({
 
   return (
     <Field className={controlledClassname} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={originalProps.name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={originalProps.name}>
         {label}
       </Label>
 

--- a/src/fields/TextInput.tsx
+++ b/src/fields/TextInput.tsx
@@ -86,7 +86,7 @@ export function TextInput({
 
   return (
     <Field className={controlledClassname} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={name}>
         {label}
       </Label>
 

--- a/src/fields/Textarea.tsx
+++ b/src/fields/Textarea.tsx
@@ -77,7 +77,7 @@ export function Textarea({
 
   return (
     <Field className={controlledClassname} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={originalProps.name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={originalProps.name}>
         {label}
       </Label>
 

--- a/src/fields/Toggle/index.tsx
+++ b/src/fields/Toggle/index.tsx
@@ -59,7 +59,7 @@ export function Toggle({
 
   return (
     <Field className={controlledClassName} style={style}>
-      <Label $isRequired={isRequired} disabled={disabled} htmlFor={originalProps.name} isHidden={isLabelHidden}>
+      <Label $idDisabled={disabled} $isHidden={isLabelHidden} $isRequired={isRequired} htmlFor={originalProps.name}>
         {label}
       </Label>
       <StyledToggle

--- a/stories/elements/Label.stories.tsx
+++ b/stories/elements/Label.stories.tsx
@@ -6,10 +6,10 @@ import type { LabelProps } from '../../src'
 import type { Meta } from '@storybook/react'
 
 const args: LabelProps = {
+  $idDisabled: false,
+  $isHidden: false,
   $isRequired: false,
-  children: 'A form input label',
-  disabled: false,
-  isHidden: false
+  children: 'A form input label'
 }
 
 /* eslint-disable sort-keys-fix/sort-keys-fix */


### PR DESCRIPTION
## BREAKING CHANGE

- `disabled` is renamed `$isDisabled` in `Label` props.
- `hasError` is renamed `$hasError` in `Label` props.
- `isHidden` is renamed `$isHidden` in `Label` props.

## Related Pull Requests & Issues

- MTES-MCT/monitorfish#3633

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-ddqzdqrqzh.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
