### PR TITLE
fix(elements)!: remove p tag & enforce string children in LinkButton

### DIFF
--- a/src/components/Banner/index.tsx
+++ b/src/components/Banner/index.tsx
@@ -125,9 +125,9 @@ export function Banner({
               />
             )}
             {!isClosable && isCollapsible && (
-              <LinkButton size={Size.LARGE}>
-                <HideText $level={level}>Masquer</HideText>
-              </LinkButton>
+              <StyledLinkButton $level={level} size={Size.LARGE}>
+                Masquer
+              </StyledLinkButton>
             )}
           </ButtonWrapper>
         </>
@@ -178,7 +178,7 @@ const ContentWrapper = styled.div<ContentWrapperProps>`
 const ButtonWrapper = styled.div`
   align-self: center;
 `
-const HideText = styled.span<{
+const StyledLinkButton = styled(LinkButton)<{
   $level: Level
 }>`
   ${p =>

--- a/src/elements/Link.tsx
+++ b/src/elements/Link.tsx
@@ -45,4 +45,4 @@ export const Link = styled.a<LinkProps>`
   }
 `
 
-Link.displayName = 'LinkButton'
+Link.displayName = 'Link'

--- a/src/elements/LinkButton.tsx
+++ b/src/elements/LinkButton.tsx
@@ -2,13 +2,12 @@ import { Size } from '@constants'
 import { THEME } from '@theme'
 import { type IconProps } from '@types_/definitions'
 import classnames from 'classnames'
-import { isString } from 'lodash'
 import { type ButtonHTMLAttributes, type FunctionComponent, type ReactNode } from 'react'
 import styled from 'styled-components'
 
 export type LinkButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   Icon?: FunctionComponent<IconProps> | undefined
-  children?: string | ReactNode | undefined
+  children: string | ReactNode
   size?: Size | undefined
 }
 export function LinkButton({ children, className, Icon, size = Size.NORMAL, ...props }: Readonly<LinkButtonProps>) {
@@ -18,7 +17,7 @@ export function LinkButton({ children, className, Icon, size = Size.NORMAL, ...p
     <StyledLinkButton $size={size} className={controlledClassName} {...props}>
       <>
         {Icon && <Icon color={THEME.color.slateGray} size={ICON_SIZE[size]} />}
-        {isString(children) ? <p>{children}</p> : <>{children}</>}
+        {children}
       </>
     </StyledLinkButton>
   )
@@ -51,6 +50,7 @@ const StyledLinkButton = styled.button<{
   &:hover,
   &._hover {
     color: ${p => p.theme.color.blueYonder};
+
     svg {
       color: ${p => p.theme.color.blueYonder};
     }
@@ -59,6 +59,7 @@ const StyledLinkButton = styled.button<{
   &:active,
   &._active {
     color: ${p => p.theme.color.blueGray};
+
     svg {
       color: ${p => p.theme.color.blueGray};
     }
@@ -67,6 +68,7 @@ const StyledLinkButton = styled.button<{
   &:disabled,
   &._disabled {
     color: ${p => p.theme.color.lightGray};
+
     svg {
       color: ${p => p.theme.color.lightGray};
     }


### PR DESCRIPTION
## BREAKING CHANGES

- `children` prop is now a required prop in `<LinkButton />`.
- `<p>` wrapper has been removed from `<LinkButton />` string  `children`.

## Related Pull Requests & Issues

None.

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-rtluwehwwf.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
