### PR TITLE
feat(fields): add hasFullDayDefaultValue to date range picker

### DIFF
--- a/e2e/base/fields/DateRangePicker.spec.tsx
+++ b/e2e/base/fields/DateRangePicker.spec.tsx
@@ -227,3 +227,39 @@ context('With time inputs', () => {
     outputShouldBe(['2023-12-11T13:34:00.000Z', '2024-01-08T23:56:59.000Z'])
   })
 })
+
+context('With default times as full day', () => {
+  beforeEach(() => {
+    mountAndWait(
+      <StoryBox>
+        <DateRangePickerStory {...(Meta.args as any)} hasFullDayDefaultValue withTime />
+      </StoryBox>
+    )
+  })
+
+  it('Should fill, change and clear the date range', () => {
+    cy.get('input[aria-label="Jour de début"]').type('01')
+
+    outputShouldBe(undefined)
+
+    cy.get('input[aria-label="Mois de début"]').type('02')
+
+    outputShouldBe(undefined)
+
+    cy.get('input[aria-label="Année de début"]').type('2023')
+
+    outputShouldBe(undefined)
+
+    cy.get('input[aria-label="Jour de fin"]').type('03')
+
+    outputShouldBe(undefined)
+
+    cy.get('input[aria-label="Mois de fin"]').type('04')
+
+    outputShouldBe(undefined)
+
+    cy.get('input[aria-label="Année de fin"]').type('2024')
+
+    outputShouldBe(['2023-02-01T00:00:00.000Z', '2024-04-03T23:59:59.000Z'])
+  })
+})

--- a/src/fields/DateRangePicker/index.tsx
+++ b/src/fields/DateRangePicker/index.tsx
@@ -328,9 +328,12 @@ export function DateRangePicker({
         if (isFilled) {
           if (withTime && hasFullDayDefaultValue) {
             closeRangeCalendarPicker()
+            forceUpdate()
+
+            return
           }
+
           handleEndDateInputNext()
-          forceUpdate()
         }
       }
     },


### PR DESCRIPTION
## Related Pull Requests & Issues

- cf. https://github.com/MTES-MCT/monitorfish/issues/3726
- Ajout de la props `hasFullDayDefaultValue`

### Vidéos 

Avec le clavier :
[Screencast from 17-10-2024 15:43:05.webm](https://github.com/user-attachments/assets/5f6c5435-3d24-428a-ab59-282a6bf4ade6)
Avec le picker :
[Screencast from 17-10-2024 15:43:56.webm](https://github.com/user-attachments/assets/bd2acb3b-70c0-4a58-ba08-ec5c28d3c6b0)


## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-ipxyfwvmmj.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
