### PR TITLE
fix(hooks): add window definition guard to NewWindowContext

### DIFF
--- a/src/hooks/useNewWindow/context.ts
+++ b/src/hooks/useNewWindow/context.ts
@@ -4,6 +4,9 @@ import type { NewWindowContextValue } from './types'
 
 export const NewWindowContext = createContext<NewWindowContextValue>({
   newWindowContainerRef: {
-    current: window.document.createElement('div')
+    // It seems monitor-ui bundle can eager-evaluate `NewWindowContext`
+    // in contexts which don't have `window` global defined.
+    // This any-forced `undefined` should never impact the real webapp initialization.
+    current: typeof window !== 'undefined' ? window.document.createElement('div') : (undefined as any)
   }
 })


### PR DESCRIPTION
## Related Pull Requests & Issues

- MTES-MCT/monitorfish#3777

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-qbgtpwknzw.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
