### PR TITLE
fix(fields): use border-box sizing for Textarea

### DIFF
--- a/src/fields/Textarea.tsx
+++ b/src/fields/Textarea.tsx
@@ -116,6 +116,7 @@ const StyledRsuiteInput = styled(RsuiteInput)<CommonFieldStyleProps>`
   width: 100%;
   min-width: 100%;
   max-width: 100%;
+  box-sizing: border-box;
 
   &::placeholder {
     color: ${getFieldPlaceholderColorFactoryForState('default')};


### PR DESCRIPTION
## Related Pull Requests & Issues

- Resolve https://github.com/MTES-MCT/monitor-ui/issues/1984
- [MTES-MCT/monitorenv#123](https://github.com/MTES-MCT/monitorfish/issues/4088#issuecomment-3664575773)

## Notes

Dans le storybook, `box-sizing: border-box` est appliqué globalement mais ce n'est pas le cas dans monitorfish. Il faut donc l'appliquer au niveau du composant `Textarea`. C'est possible qu'il y ai des disparité dans plusieurs autres composants a cause de ça.

Idéalement il faudrait aligner le style global entre la lib et les apps pour éviter ce genre de problèmes. Peut-être via un style global défini dans monitor-ui à importer dans les apps.

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-xvobbbcori.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
