### PR TITLE
fix(fields): show full label on hover for truncated CheckTreePicker items

### DIFF
--- a/src/fields/CheckTreePicker/index.tsx
+++ b/src/fields/CheckTreePicker/index.tsx
@@ -510,6 +510,14 @@ const IconExpander = styled.div`
   display: flex;
   align-items: center;
   cursor: pointer;
+  /* Its containing rsuite element (.rs-tree-node-custom-icon) collapses to 0x0, so this
+   * absolutely positioned box escapes to the whole row. Without this, it silently intercepts
+   * hover/click on the row's label too, blocking the label's title tooltip. */
+  pointer-events: none;
+
+  > * {
+    pointer-events: auto;
+  }
 `
 
 const Wrapper = styled.div`

--- a/src/fields/CheckTreePicker/index.tsx
+++ b/src/fields/CheckTreePicker/index.tsx
@@ -310,7 +310,11 @@ export function CheckTreePicker({
         return item[labelKey] as React.ReactNode
       }
 
-      return <AccentInsensitiveHighlight label={item[labelKey]} query={searchKeyword} />
+      return (
+        <span title={item[labelKey]}>
+          <AccentInsensitiveHighlight label={item[labelKey]} query={searchKeyword} />
+        </span>
+      )
     },
     [labelKey, searchKeyword]
   )


### PR DESCRIPTION
Long option labels in the CheckTreePicker popup are ellipsis-truncated by rsuite's default styling with no way to read the full text, so add a title attribute to reveal it on hover.

## Related Pull Requests & Issues

- Resolve https://github.com/MTES-MCT/monitorfish/issues/5260

## Preview URL

<!-- AUTOFILLED_PREVIEW_URL -->
https://637e01cf5934a2ae881ccc9d-aaeqvmercx.chromatic.com/
<!-- AUTOFILLED_PREVIEW_URL -->
